### PR TITLE
Fixing some sample config issues

### DIFF
--- a/samples/grids/grid/action-strip.json
+++ b/samples/grids/grid/action-strip.json
@@ -60,21 +60,21 @@
           "field": "Discontinued",
           "header": "Discontinued"
         }
-      ]
-    },
-    "actionStrip": {
-      "type": "WebActionStrip",
-      "name": "actionStrip",
-      "actionButtons": [
-        {
-          "type": "WebGridPinningActions"
-        }, 
-        {
-          "type": "WebGridEditingActions",
-          "editRow": true, 
-          "deleteRow": false
-        }
-      ]
+      ],
+      "actionStrip": {
+        "type": "WebActionStrip",
+        "name": "actionStrip",
+        "actionButtons": [
+          {
+            "type": "WebGridPinningActions"
+          }, 
+          {
+            "type": "WebGridEditingActions",
+            "editRow": true, 
+            "deleteRow": false
+          }
+        ]
+      }
     }
   },
   "modules": [

--- a/samples/grids/grid/column-moving-options.json
+++ b/samples/grids/grid/column-moving-options.json
@@ -84,6 +84,7 @@
     }
   },
   "modules": [
-    "grids/WebGridModule"
+    "grids/WebGridModule",
+    "BadgeModule"
   ]
 }

--- a/samples/grids/grid/column-pinning-right-side.json
+++ b/samples/grids/grid/column-pinning-right-side.json
@@ -87,6 +87,7 @@
     }
   },
   "modules": [
-    "grids/WebGridModule"
+    "grids/WebGridModule",
+    "AvatarModule"
   ]
 }

--- a/samples/grids/grid/row-editing-options.json
+++ b/samples/grids/grid/row-editing-options.json
@@ -8,6 +8,7 @@
       "name": "grid",
       "id": "grid",
       "displayDensity": "Compact",
+      "primaryKey": "ProductID",
       "rowEditable": true,
       "columns": [
         {

--- a/samples/grids/grid/row-paging-basic.json
+++ b/samples/grids/grid/row-paging-basic.json
@@ -52,6 +52,7 @@
     }
   },
   "modules": [
-    "grids/WebGridModule"
+    "grids/WebGridModule",
+    "LinearProgressModule"
   ]
 }

--- a/samples/grids/grid/row-selection-mode.json
+++ b/samples/grids/grid/row-selection-mode.json
@@ -89,8 +89,7 @@
   },
   "modules": [
     "grids/WebGridModule",
-    "PropertyEditorModule",
-    "PropertyEditorPanelModule",
+    "layouts/PropertyEditorPanelModule",
     "BadgeModule"
   ]
 }

--- a/samples/grids/grid/row-selection-mode.json
+++ b/samples/grids/grid/row-selection-mode.json
@@ -90,6 +90,7 @@
   "modules": [
     "grids/WebGridModule",
     "PropertyEditorModule",
-    "PropertyEditorPanelModule"
+    "PropertyEditorPanelModule",
+    "BadgeModule"
   ]
 }


### PR DESCRIPTION
Fixing some minor sample config issues:
 - Fix issue with row editing not opening due to missing primary key - Closes #112
- Move action strip to be inside the grid so that it generates - Closes #124 
- Add modules of components used in the templates. 
- Fix issue with property editor not registering in exported sample. - Closes #134