### PR TITLE
Doc related sample improvements

### DIFF
--- a/samples/grids/grid/clipboard-operations.json
+++ b/samples/grids/grid/clipboard-operations.json
@@ -2,7 +2,7 @@
   "todo": [
     ""
   ],
-  "export": true,
+  "export": false,
   "skipAlterDataCasing": true,
   "descriptions": {
     "editor": {

--- a/samples/grids/grid/clipboard-operations.json
+++ b/samples/grids/grid/clipboard-operations.json
@@ -1,6 +1,6 @@
 {
   "todo": [
-    ""
+    "The property editor bindings to complex properties don't seem to work, hence skipping this sample."
   ],
   "export": false,
   "skipAlterDataCasing": true,

--- a/samples/grids/grid/conditional-cell-style-1.json
+++ b/samples/grids/grid/conditional-cell-style-1.json
@@ -1,6 +1,6 @@
 {
-  "todo": [ "" ],
-  "export": true,
+  "todo": [ "Conditional Cell Classes sample - Can set the cellClassesRef property but cannot set css class. Deferred until until we support injecting CSS classes." ],
+  "export": false,
   "skipAlterDataCasing": true,
   "descriptions": {
     "content": {

--- a/samples/grids/grid/conditional-cell-style-2.json
+++ b/samples/grids/grid/conditional-cell-style-2.json
@@ -1,8 +1,7 @@
 {
-  "todo": [ 
-     "Approved Defer - until we support CSS"
+  "todo": [
   ],
-  "export": false,
+  "export": true,
   "skipAlterDataCasing": true,
   "descriptions": {
     "content": {
@@ -13,23 +12,29 @@
       "columns": [
         {
           "type": "WebColumn",
-          "field": "Id"
+          "field": "Id",
+          "cellStylesRef": "WebGridCellStylesHandler"
         },
         {
           "type": "WebColumn",
-          "field": "Position"
+          "field": "Position",
+          "cellStylesRef": "WebGridCellStylesHandler"
+          
         },
         {
           "type": "WebColumn",
-          "field": "Name"
+          "field": "Name",
+          "cellStylesRef": "WebGridCellStylesHandler"
         },
         {
           "type": "WebColumn",
-          "field": "AthleteNumber"
+          "field": "AthleteNumber",
+          "cellStylesRef": "WebGridCellStylesHandler"
         },
         {
           "type": "WebColumn",
-          "field": "CountryName"
+          "field": "CountryName",
+          "cellStylesRef": "WebGridCellStylesHandler"
         }
       ]
     }

--- a/samples/grids/grid/data-performance-virtualization.json
+++ b/samples/grids/grid/data-performance-virtualization.json
@@ -120,7 +120,7 @@
     },
     "modules": [
       "grids/WebGridModule",
-      "BadgeModule"
+      "webinputs/WebBadgeModule"
     ]
   }
   

--- a/samples/grids/grid/data-performance-virtualization.json
+++ b/samples/grids/grid/data-performance-virtualization.json
@@ -1,122 +1,126 @@
 {
-  "todo": [
-      "MT port FinancialDataService in Blazor.cs - see Financial Stocks",
-      "add cell templates for Change, ChangePercent and AnnualChange fields"
-  ],
-  "skipAlterDataCasing": true,
-  "descriptions": {
-    "content": {
-      "type": "WebGrid",
-      "dataRef": "FinancialDataAll",
-      "autoGenerate": false,
-      "name": "grid",
-      "id": "grid",
-      "allowFiltering": true,
-      "columns": [
-        {
-            "type": "WebColumn",
-            "field": "Category",
-            "width": "120px"
-        },
-        {
-            "type": "WebColumn",
-            "field": "Type",
-            "filterable": false,
-            "width": "150px"
-        },
-        {
-            "type": "WebColumn",
-            "field": "Open",
-            "width": "120px",
-            "dataType": "Currency"
-        },
-        {
-            "type": "WebColumn",
-            "field": "Price",
-            "width": "120px",
-            "dataType": "Currency"
-        },
-        {
-            "type": "WebColumn",
-            "field": "Change",
-            "width": "120px",
-            "dataType": "Number"
-        },
-        {
-            "type": "WebColumn",
-            "field": "ChangePercent",
-            "header": "Change(%)",
-            "width": "120px",
-            "dataType": "Number"
-        },
-        {
-            "type": "WebColumn",
-            "field": "AnnualChange",
-            "header": "Change On Year(%)",
-            "width": "150px",
-            "dataType": "Number"
-        },
-        {
-            "type": "WebColumn",
-            "field": "Buy",
-            "width": "130px",
-            "dataType": "Currency"
-        },
-        {
-            "type": "WebColumn",
-            "field": "Sell",
-            "width": "130px",
-            "dataType": "Currency"
-        },
-        {
-            "type": "WebColumn",
-            "field": "Spread",
-            "width": "130px",
-            "dataType": "Number"
-        },
-        {
-            "type": "WebColumn",
-            "field": "Volume",
-            "width": "130px",
-            "dataType": "Number"
-        },
-        {
-            "type": "WebColumn",
-            "field": "High",
-            "width": "130px",
-            "dataType": "Currency"
-        },
-        {
-            "type": "WebColumn",
-            "field": "Low",
-            "width": "130px",
-            "dataType": "Currency"
-        },
-        {
-            "type": "WebColumn",
-            "field": "AnnualHigh",
-            "header": "High(Y)",
-            "width": "130px",
-            "dataType": "Currency"
-        },
-        {
-            "type": "WebColumn",
-            "field": "AnnualLow",
-            "header": "Low(Y)",
-            "width": "130px",
-            "dataType": "Currency"
-        },
-        {
-            "type": "WebColumn",
-            "field": "AnnualStart",
-            "header": "Start(Y)",
-            "width": "130px",
-            "dataType": "Currency"
-        }
-      ]
-    }
-  },
-  "modules": [
-    "grids/WebGridModule"
-  ]
-}
+    "todo": [
+        "MT port FinancialDataService in Blazor.cs - see Financial Stocks"
+    ],
+    "skipAlterDataCasing": true,
+    "descriptions": {
+      "content": {
+        "type": "WebGrid",
+        "dataRef": "FinancialDataAll",
+        "autoGenerate": false,
+        "name": "grid",
+        "id": "grid",
+        "allowFiltering": true,
+        "columns": [
+          {
+              "type": "WebColumn",
+              "field": "Category",
+              "width": "120px"
+          },
+          {
+              "type": "WebColumn",
+              "field": "Type",
+              "filterable": false,
+              "width": "150px"
+          },
+          {
+              "type": "WebColumn",
+              "field": "Open",
+              "width": "120px",
+              "dataType": "Currency"
+          },
+          {
+              "type": "WebColumn",
+              "field": "Price",
+              "width": "120px",
+              "dataType": "Currency"
+          },
+          {
+              "type": "WebColumn",
+              "field": "Change",
+              "width": "120px",
+              "dataType": "Number",
+              "bodyTemplateRef": "WebGridCurrencyCellTemplate"
+          },
+          {
+              "type": "WebColumn",
+              "field": "ChangePercent",
+              "header": "Change(%)",
+              "width": "120px",
+              "dataType": "Number",
+              "bodyTemplateRef": "WebGridCurrencyCellTemplate"
+          },
+          {
+              "type": "WebColumn",
+              "field": "AnnualChange",
+              "header": "Change On Year(%)",
+              "width": "150px",
+              "dataType": "Number",
+              "bodyTemplateRef": "WebGridCurrencyCellTemplate"
+          },
+          {
+              "type": "WebColumn",
+              "field": "Buy",
+              "width": "130px",
+              "dataType": "Currency"
+          },
+          {
+              "type": "WebColumn",
+              "field": "Sell",
+              "width": "130px",
+              "dataType": "Currency"
+          },
+          {
+              "type": "WebColumn",
+              "field": "Spread",
+              "width": "130px",
+              "dataType": "Number"
+          },
+          {
+              "type": "WebColumn",
+              "field": "Volume",
+              "width": "130px",
+              "dataType": "Number"
+          },
+          {
+              "type": "WebColumn",
+              "field": "High",
+              "width": "130px",
+              "dataType": "Currency"
+          },
+          {
+              "type": "WebColumn",
+              "field": "Low",
+              "width": "130px",
+              "dataType": "Currency"
+          },
+          {
+              "type": "WebColumn",
+              "field": "AnnualHigh",
+              "header": "High(Y)",
+              "width": "130px",
+              "dataType": "Currency"
+          },
+          {
+              "type": "WebColumn",
+              "field": "AnnualLow",
+              "header": "Low(Y)",
+              "width": "130px",
+              "dataType": "Currency"
+          },
+          {
+              "type": "WebColumn",
+              "field": "AnnualStart",
+              "header": "Start(Y)",
+              "width": "130px",
+              "dataType": "Currency"
+          }
+        ]
+      }
+    },
+    "modules": [
+      "grids/WebGridModule",
+      "BadgeModule"
+    ]
+  }
+  

--- a/samples/grids/grid/data-summary-formatter.json
+++ b/samples/grids/grid/data-summary-formatter.json
@@ -1,5 +1,4 @@
 {
-  "todo": ["missing summary formatter prop"],
   "export": true,
   "skipAlterDataCasing": true,
   "descriptions": {
@@ -39,10 +38,7 @@
           "sortable": true,
           "hasSummary": true,
           "dataType": "Date",
-          "pipeArgs": {
-              "type": "WebColumnPipeArgs",
-              "format": "MMM YYYY"
-          }
+          "summaryFormatterRef": "WebGridSummaryFormatter"
         },
         {
           "type": "WebColumn",

--- a/samples/grids/grid/filtering-options.json
+++ b/samples/grids/grid/filtering-options.json
@@ -9,7 +9,7 @@
       "moving": true,
       "autoGenerate": false,
       "allowFiltering": true,
-      "filterMode": "ExcelStyleFilter",
+      "filterMode": "QuickFilter",
       "columns": [{
         "type": "WebColumn",
         "name": "ProductName",

--- a/samples/grids/grid/groupby-custom.json
+++ b/samples/grids/grid/groupby-custom.json
@@ -3,7 +3,7 @@
     "Andrew - add template column with event handlers",
     "Andrew - add grid toolbar when available"
   ],
-  "export": true,
+  "export": false,
   "skipAlterDataCasing": true,
   "descriptions": {
     "content": {

--- a/samples/grids/grid/groupby-custom.json
+++ b/samples/grids/grid/groupby-custom.json
@@ -1,7 +1,6 @@
 {
   "todo": [ 
-    "Andrew - add template column with event handlers",
-    "Andrew - add grid toolbar when available"
+    "This sample needs custom UI with handlers and custom code that cannot be done via the Editor ATM, hence skipping it."
   ],
   "export": false,
   "skipAlterDataCasing": true,

--- a/samples/grids/grid/groupby-expressions.json
+++ b/samples/grids/grid/groupby-expressions.json
@@ -7,7 +7,7 @@
   "descriptions": {
     "content": {
       "type": "WebGrid",
-      "dataRef": "InvoicesData",
+      "dataRef": "InvoicesWorldData",
       "autoGenerate": false,
       "name": "grid",
       "id": "grid",

--- a/samples/grids/grid/groupby-paging.json
+++ b/samples/grids/grid/groupby-paging.json
@@ -13,7 +13,7 @@
       "type": "WebGrid",
       "name": "grid",
       "id": "grid",
-      "dataRef": "InvoicesData",
+      "dataRef": "InvoicesWorldData",
       "rowSelection": "Multiple",
       "autoGenerate": false,
       "groupingExpressions": [

--- a/samples/grids/grid/groupby-summary-styling.json
+++ b/samples/grids/grid/groupby-summary-styling.json
@@ -1,8 +1,8 @@
 {
   "todo": [
-    ""
+    "Defer - until we can inject CSS styles"
   ],
-  "export": true,
+  "export": false,
   "skipAlterDataCasing": true,
   "descriptions": {
     "editor": {

--- a/samples/grids/grid/groupby-summary-styling.json
+++ b/samples/grids/grid/groupby-summary-styling.json
@@ -1,8 +1,8 @@
 {
   "todo": [
-    "Defer - until we can inject CSS styles"
+    ""
   ],
-  "export": false,
+  "export": true,
   "skipAlterDataCasing": true,
   "descriptions": {
     "editor": {

--- a/samples/grids/grid/keyboard-custom-navigation.json
+++ b/samples/grids/grid/keyboard-custom-navigation.json
@@ -1,8 +1,7 @@
 {
-  "todo": [ 
-     "Approved Defer - until we have keyboard events"
+  "todo": [
   ], 
-  "export": false,
+  "export": true,
   "skipAlterDataCasing": true,
   "descriptions": {
     "content": {
@@ -14,6 +13,7 @@
       "autoGenerate": false,
       "displayDensity": "Cosy",
       "rowEditable": true,
+      "gridKeydownRef": "WebGridCustomKBNav",
       "columns": [
         {
           "type": "WebColumn",
@@ -25,7 +25,8 @@
           "type": "WebColumn",
           "name": "ReorderLevel",
           "field": "ReorderLevel",
-          "header": "Reorder Level"
+          "header": "Reorder Level",
+          "dataType": "Number"
         },
         {
           "type": "WebColumn",
@@ -37,7 +38,8 @@
           "type": "WebColumn",
           "name": "UnitsInStock",
           "field": "UnitsInStock",
-          "header": "Units In Stock"
+          "header": "Units In Stock",
+          "dataType": "Number"
         },
         {
           "type": "WebColumn",

--- a/samples/grids/grid/overview.json
+++ b/samples/grids/grid/overview.json
@@ -21,16 +21,6 @@
       "columns": [
         {
           "type": "WebColumn",
-          "field": "ProductID",
-          "header": "Product ID",
-          "dataType": "Number",
-          "sortable": true,
-          "hasSummary": true,
-          "editable": true,
-          "resizable": true
-        },
-        {
-          "type": "WebColumn",
           "field": "ProductName",
           "header": "Product Name",
           "dataType": "String",
@@ -76,7 +66,8 @@
           "dataType": "Boolean",
           "sortable": true,
           "hasSummary": true,
-          "editable": true
+          "editable": true,
+          "bodyTemplateRef": "WebGridBooleanCellTemplate"
         },
         {
           "type": "WebColumn",

--- a/samples/grids/grid/row-paging-options.json
+++ b/samples/grids/grid/row-paging-options.json
@@ -19,7 +19,6 @@
           "name": "paginator",
           "perPage": 15,
           "displayDensity": "Cosy",
-          "selectOptions": [5, 15, 20, 50],
           "resourceStrings": {
             "type": "WebPaginatorResourceStrings",
             "igx_paginator_label": "Records per page"

--- a/samples/grids/grid/row-pinning-extra-column.json
+++ b/samples/grids/grid/row-pinning-extra-column.json
@@ -1,7 +1,5 @@
 {
     "todo": [
-        "TODO add switch to toggle row pinning position",
-        "TODO add template column with icon for pinning",
         "TODO add event to handle row pinning"
     ],
   "skipAlterDataCasing": true,
@@ -17,7 +15,8 @@
                     "type": "WebColumn",
                     "width": "70px",
                     "filterable": false,
-                    "pinned": true
+                    "pinned": true,
+                    "bodyTemplateRef": "WebGridRowPinCellTemplate"
                 },
                 {
                     "type": "WebColumn",

--- a/samples/grids/grid/row-reorder.json
+++ b/samples/grids/grid/row-reorder.json
@@ -7,6 +7,7 @@
       "dataRef": "CustomersData",
       "rowDraggable": true,
       "primaryKey": "ID",
+      "rowDragEndRef": "WebGridReorderRowHandler",
       "columns": [
         {
           "type": "WebColumn",

--- a/samples/grids/grid/row-selection-template-excel.json
+++ b/samples/grids/grid/row-selection-template-excel.json
@@ -1,7 +1,5 @@
 {
   "todo": [
-    "TODO ability to select multiple rows by clicking the button",
-    "TODO the row number on the left on every line"
   ],
   "export": true,
   "skipAlterDataCasing": true,
@@ -13,6 +11,9 @@
       "name": "grid",
       "id": "grid",
       "displayDensity": "Cosy",
+      "rowSelection": "Multiple",
+      "rowSelectorTemplateRef": "WebGridRowSelectorExcelTemplate",
+      "headSelectorTemplateRef": "WebGridHeaderRowSelectorExcelTemplate",
       "paginationComponents": [
         {
           "type": "WebPaginator",
@@ -51,22 +52,6 @@
           "type": "WebColumn",
           "field": "CompanyName",
           "header": "Company"
-        }
-      ]
-    },
-    "editor": {
-      "type": "PropertyEditorPanel",
-      "name": "PropertyEditor",
-      "componentRendererRef": "renderer",
-      "targetRef": "grid",
-      "descriptionType": "WebGrid",
-      "isHorizontal": true,
-      "isWrappingEnabled": true,
-      "properties": [
-        {
-          "type": "PropertyEditorPropertyDescription",
-          "name": "selectionType",
-          "propertyPath": "RowSelection"
         }
       ]
     }

--- a/samples/grids/grid/row-selection-template-numbers.json
+++ b/samples/grids/grid/row-selection-template-numbers.json
@@ -37,6 +37,7 @@
   },
   "modules": [
     "withDescriptions",
-    "grids/WebGridModule"
+    "grids/WebGridModule",
+    "webinputs/WebCheckboxModule"
   ]
 }

--- a/samples/grids/grid/row-styles.json
+++ b/samples/grids/grid/row-styles.json
@@ -1,8 +1,7 @@
 {
   "todo": [
-    "Add working WebGridCurrencyCellTemplate with badge and icon"
   ],
-  "export": false,
+  "export": true,
   "skipAlterDataCasing": true,
   "descriptions": {
     "content": {
@@ -42,14 +41,16 @@
           "type": "WebColumn",
           "field": "Change",
           "width": "120px",
-          "dataType": "Number"
+          "dataType": "Number",
+          "bodyTemplateRef": "WebGridCurrencyCellTemplate"
         },
         {
           "type": "WebColumn",
           "field": "ChangePercent",
           "header": "Change(%)",
           "width": "120px",
-          "dataType": "Number"
+          "dataType": "Percent",
+          "bodyTemplateRef": "WebGridCurrencyCellTemplate"
         },
         {
           "type": "WebColumn",
@@ -121,6 +122,7 @@
     }
   },
   "modules": [
-    "grids/WebGridModule"
+    "grids/WebGridModule",
+    "BadgeModule"
   ]
 }

--- a/samples/grids/grid/row-styles.json
+++ b/samples/grids/grid/row-styles.json
@@ -123,6 +123,6 @@
   },
   "modules": [
     "grids/WebGridModule",
-    "BadgeModule"
+    "webinputs/WebBadgeModule"
   ]
 }

--- a/samples/grids/grid/toolbar-sample-2.json
+++ b/samples/grids/grid/toolbar-sample-2.json
@@ -17,7 +17,7 @@
               "type": "WebGridToolbarActions",
               "actions": [
                 {
-                  "type": "WebBaseToolbarColumnActionsDirective"
+                  "type": "WebGridToolbarAdvancedFiltering"
                 },
                 {
                   "type": "WebGridToolbarHiding"

--- a/samples/grids/grid/toolbar-sample-3.json
+++ b/samples/grids/grid/toolbar-sample-3.json
@@ -9,6 +9,7 @@
       "type": "WebGrid",
       "dataRef": "AthletesData",
       "autoGenerate": false,
+      "toolbarExportingRef": "WebGridToolbarExporting",
       "toolbar": [
         {
           "type": "WebGridToolbar",

--- a/samples/grids/grid/toolbar-sample-4.json
+++ b/samples/grids/grid/toolbar-sample-4.json
@@ -1,8 +1,9 @@
 {
   "todo": [ 
-     ""
+     "No option to set custom content inside the toolbar via the editor."
   ],
   "skipAlterDataCasing": true,
+  "export": false,
   "descriptions": {
     "content": {
       "type": "WebGrid",

--- a/samples/grids/tree-grid/clipboard-operations.json
+++ b/samples/grids/tree-grid/clipboard-operations.json
@@ -1,8 +1,5 @@
 {
-  "todo": [
-    ""
-  ],
-  "export": true,
+  "export": false,
   "skipAlterDataCasing": true,
   "descriptions": {
     "editor": {


### PR DESCRIPTION
- Grid overview sample - remove pk column, add  a template as the topic around the sample mentions cell templating.  -  Verified  :heavy_check_mark:
- Grid custom group by sample - remove it as custom group is too custom and cannot be configured via the editor.  It also cannot be configured at all for Blazor, so there'll be just a web component sample. 
- Grid/TreeGrid clipboard operations sample - removing it since sample's property editors do not work in it so we'll add separate samples for WC and Blazor. 
- Enable row and cell conditional styling samples. Note that their code gen templates are also updated.  -  Verified  :heavy_check_mark:
- Disable conditional cell classes - they need css injection. Will be implemented in wc/blazor samples for now. 
- Remove selectOptions from paging sample since it generates incorrectly in WC.  -  Verified  :heavy_check_mark:
- Use different data for grouping samples.  -  Verified  :heavy_check_mark:
- Add summary formatter to summary formatter sample. -  Verified  :heavy_check_mark:
- Update virtualization sample to use templates.  -  Verified  :heavy_check_mark:
- Enable custom grid navigation sample. -  Verified  :heavy_check_mark:
- Add handler that reorders rows for row reorder sample.  -  Verified  :heavy_check_mark:
- Add custom row pinning column template.
- Add checkbox module to row selection template sample that uses igc-checkbox,  -  Verified  :heavy_check_mark:
- Add excel-like select templates for Excel Style Row Selectors sample.  -  Verified  :heavy_check_mark:
- Minor fixed for toolbar samples. -  Verified  :heavy_check_mark:
- Disable custom toolbar content sample since it is not possible to configure it via the editor (https://infragistics.visualstudio.com/NetAdvantage/_workitems/edit/24787)  -  Verified  :heavy_check_mark:
- Change main filtering sample to use QuickFilter.  -  Verified  :heavy_check_mark: