### PR TITLE
mdd-fix-format-specifiers

### DIFF
--- a/samples/charts/category-chart/format-specifiers.json
+++ b/samples/charts/category-chart/format-specifiers.json
@@ -12,7 +12,6 @@
     },
     "content": {
       "type": "CategoryChart",
-      "legendRef": "Legend",
       "name": "chart",
       "dataSourceRef": "HighestGrossingMovies",
       "chartType": "Column",

--- a/samples/charts/data-chart/format-specifiers.json
+++ b/samples/charts/data-chart/format-specifiers.json
@@ -13,7 +13,6 @@
     "content": {
       "type": "DataChart",
       "name": "chart",
-      "legendRef": "Legend",
       "axes": [
         {
           "type": "CategoryYAxis",


### PR DESCRIPTION
removed legendRef property from both data-chart and category-chart samples