### PR TITLE
Set data for cascading combo to 3 rows for React, similar to other platforms.

### DIFF
--- a/code-gen-library/WebGridWithComboRendered/React.tsx
+++ b/code-gen-library/WebGridWithComboRendered/React.tsx
@@ -1,13 +1,16 @@
 //begin imports
-import { IgrCombo } from 'igniteui-react';
+import { IgrCombo, IgrVoidEventArgs } from 'igniteui-react';
+import { IgrGrid } from 'igniteui-react-grids';
 //end imports
 
 
 export class WebGridWithComboRendered {
     //begin eventHandler
-    public webGridWithComboRendered(args: any) {
-        console.log(args);
-    }
+    public gridData = [
+        { ID: 1, Country: '', Region: '', City: '' },
+        { ID: 2, Country: '', Region: '', City: '' },
+        { ID: 3, Country: '', Region: '', City: '' }
+    ];
     public countryNames = [
         'United States',
         'Japan',
@@ -23,6 +26,9 @@ export class WebGridWithComboRendered {
         }
     }
 
+    public webGridWithComboRendered(gridRef: IgrGrid, args: IgrVoidEventArgs) {
+        gridRef.data = this.gridData;
+    }
 
     public onCountryChange( rowId: string, cmp: any, args:any) {
         // find next combo


### PR DESCRIPTION
Resolves https://github.com/IgniteUI/igniteui-react-examples/issues/671 since the sample appears to be auto-generated.