### PR TITLE
add name property to PropertyEditorPropertyDescriptions 

### DIFF
--- a/samples/charts/data-pie-chart/animation.json
+++ b/samples/charts/data-pie-chart/animation.json
@@ -15,12 +15,14 @@
         {
           "type": "PropertyEditorPropertyDescription",
           "propertyPath": "TransitionInMode",
+          "name": "TransitionInModeEditor",
           "label": "Transition In Animation: ",
           "primitiveValue": "Auto"
         },
         {
           "type": "PropertyEditorPropertyDescription",
           "propertyPath": "TransitionInSpeedType",
+          "name": "TransitionInSpeedTypeEditor",
           "label": "Transition In Speed Type: ",
           "primitiveValue": "Random"
         }

--- a/samples/charts/data-pie-chart/highlighting.json
+++ b/samples/charts/data-pie-chart/highlighting.json
@@ -15,12 +15,14 @@
         {
           "type": "PropertyEditorPropertyDescription",
           "propertyPath": "HighlightingMode",
+          "name": "HighlightingModeEditor",
           "label": "Highlighting Mode: ",
           "primitiveValue": "BrightenSpecific"
         },
         {
           "type": "PropertyEditorPropertyDescription",
           "propertyPath": "HighlightingBehavior",
+          "name": "HighlightingBehaviorEditor",
           "label": "Highlighting Behavior: ",
           "primitiveValue": "DirectlyOver"
         }

--- a/samples/charts/data-pie-chart/others.json
+++ b/samples/charts/data-pie-chart/others.json
@@ -15,6 +15,7 @@
         {
           "type": "PropertyEditorPropertyDescription",
           "propertyPath": "OthersCategoryType",
+          "name": "OthersCategoryTypeEditor",
           "label": "Others Type: ",
           "primitiveValue": "Number",
           "valueType": "EnumValue"
@@ -22,6 +23,7 @@
         {
           "type": "PropertyEditorPropertyDescription",
           "propertyPath": "OthersCategoryThreshold",
+          "name": "OthersCategoryThresholdEditor",
           "label": "Others Threshold: ",
           "valueType": "Slider",
           "min": 0,
@@ -31,6 +33,7 @@
         {
           "type": "PropertyEditorPropertyDescription",
           "propertyPath": "OthersCategoryText",
+          "name": "OthersCategoryTextEditor",
           "label": "Others Text: ",
           "valueType": "StringValue"
         }

--- a/samples/charts/data-pie-chart/selection.json
+++ b/samples/charts/data-pie-chart/selection.json
@@ -16,8 +16,8 @@
           "type": "PropertyEditorPropertyDescription",
           "label": "Selection Behavior: ",
           "valueType": "EnumValue",
-          "propertyPath": "SelectionBehavior",
-          "name": "SelectionBehavior",
+          "propertyPath": "SelectionBehavior",   
+          "name": "SelectionBehaviorEditor",
           "shouldOverrideDefaultEditor": true,
           "dropDownNames": ["PerDataItemSingleSelect", "PerDataItemMultiSelect"],
           "dropDownValues": ["PerDataItemSingleSelect", "PerDataItemMultiSelect"],
@@ -26,6 +26,7 @@
         {
           "type": "PropertyEditorPropertyDescription",
           "propertyPath": "SelectionMode",
+          "name": "SelectionModeEditor",
           "label": "Selection Mode: ",
           "primitiveValue": "Brighten"
         }

--- a/samples/charts/toolbar/theming.json
+++ b/samples/charts/toolbar/theming.json
@@ -11,6 +11,7 @@
         {
           "type": "PropertyEditorPropertyDescription",
           "propertyPath": "BaseTheme",
+          "name": "BaseThemeEditor",
           "label": "Theme",
           "shouldOverrideDefaultEditor": true,
           "valueType": "EnumValue",


### PR DESCRIPTION
add name property to PropertyEditorPropertyDescriptions to prevent error in React : each child must have a unique key or name property