### PR TITLE
Adding Edit Templates on Grid Cell Editing

### DIFF
--- a/code-gen-library/WebGridNumericColEditCellTemplate/Blazor.js
+++ b/code-gen-library/WebGridNumericColEditCellTemplate/Blazor.js
@@ -1,0 +1,19 @@
+//begin template
+igRegisterScript("WebGridNumericColEditCellTemplate", (ctx) => {
+    var html = window.igTemplating.html;
+    const cell = ctx.cell;
+    const columnName = cell.column.field;
+    const cellValue = cell.row.data[columnName];
+
+    return html`
+        <igc-input 
+            type="number"
+            name="${cell.id.rowID}"
+            style="width: 100%;"
+            value="${cellValue}"
+            @igcChange=${(e) => {
+                cell.editValue = e.detail;
+            }}>
+        </igc-input>`
+}, false);
+//end template

--- a/code-gen-library/WebGridNumericColEditCellTemplate/Blazor.js
+++ b/code-gen-library/WebGridNumericColEditCellTemplate/Blazor.js
@@ -4,10 +4,14 @@ igRegisterScript("WebGridNumericColEditCellTemplate", (ctx) => {
     const cell = ctx.cell;
     const columnName = cell.column.field;
     const cellValue = cell.row.data[columnName];
-
+    const rowId = cell.id.rowID;
+    const columnId = cell.id.columnID;
+    const inputTemplateId = `edit-cell-${rowId}-${columnId}`;
+    
     return html`
         <igc-input 
             type="number"
+            id="${inputTemplateId}"
             name="${cell.id.rowID}"
             style="width: 100%;"
             value="${cellValue}"

--- a/code-gen-library/WebGridNumericColEditCellTemplate/React.tsx
+++ b/code-gen-library/WebGridNumericColEditCellTemplate/React.tsx
@@ -9,10 +9,14 @@ export class WebGridNumericColEditCellTemplate {
     public webGridNumericColEditCellTemplate = (e: { dataContext: IgrCellTemplateContext }) => {
 
         const cell = e.dataContext.cell;
+        const rowId = cell.id.rowID;
+        const columnId = cell.id.columnID;
+        const inputTemplateId = `edit-cell-${rowId}-${columnId}`;
 
         return (
             <IgrInput 
-                type="number" 
+                type="number"
+                id={inputTemplateId} 
                 name={cell.id.rowID} 
                 value={cell.editValue} 
                 inputOcurred={(s:any, e: any) => {

--- a/code-gen-library/WebGridNumericColEditCellTemplate/React.tsx
+++ b/code-gen-library/WebGridNumericColEditCellTemplate/React.tsx
@@ -1,0 +1,27 @@
+//begin imports
+import { IgrCellTemplateContext } from 'igniteui-react-grids';
+import { IgrInput } from 'igniteui-react';
+//end imports
+
+export class WebGridNumericColEditCellTemplate {
+    //begin template
+    //begin content
+    public webGridNumericColEditCellTemplate = (e: { dataContext: IgrCellTemplateContext }) => {
+
+        const cell = e.dataContext.cell;
+
+        return (
+            <IgrInput 
+                type="number" 
+                name={cell.id.rowID} 
+                value={cell.editValue} 
+                inputOcurred={(s:any, e: any) => {
+                    cell.editValue = e.detail;
+                }} 
+                style={{width: "100%"}}
+            />
+        );
+    }
+    //end content
+    //end template
+}

--- a/code-gen-library/WebGridNumericColEditCellTemplate/WebComponents.ts
+++ b/code-gen-library/WebGridNumericColEditCellTemplate/WebComponents.ts
@@ -1,0 +1,27 @@
+//begin imports
+import { IgcCellTemplateContext } from 'igniteui-webcomponents-grids/grids';
+import { html } from 'lit-html';
+//end imports
+
+export class WebGridNumericColEditCellTemplate {
+//begin template
+//begin content
+public webGridNumericColEditCellTemplate = (ctx: IgcCellTemplateContext) => {
+    const cell = ctx.cell;
+    const columnName = cell.column.field;
+    const cellValue = cell.row.data[columnName];
+
+    return html`
+        <igc-input 
+            type="number"
+            name="${cell.id.rowID}"
+            style="width: 100%;"
+            value="${cellValue}"
+            @igcChange=${(e: any) => {
+                cell.editValue = e.detail;
+            }}>
+        </igc-input>`;
+}
+//end content
+//end template
+}

--- a/code-gen-library/WebGridNumericColEditCellTemplate/WebComponents.ts
+++ b/code-gen-library/WebGridNumericColEditCellTemplate/WebComponents.ts
@@ -10,10 +10,14 @@ public webGridNumericColEditCellTemplate = (ctx: IgcCellTemplateContext) => {
     const cell = ctx.cell;
     const columnName = cell.column.field;
     const cellValue = cell.row.data[columnName];
-
+    const rowId = cell.id.rowID;
+    const columnId = cell.id.columnID;
+    const inputTemplateId = `edit-cell-${rowId}-${columnId}`;
+    
     return html`
         <igc-input 
             type="number"
+            id="${inputTemplateId}"
             name="${cell.id.rowID}"
             style="width: 100%;"
             value="${cellValue}"

--- a/code-gen-library/WebGridOnEditEnter/Blazor.js
+++ b/code-gen-library/WebGridOnEditEnter/Blazor.js
@@ -1,0 +1,14 @@
+//begin eventHandler
+igRegisterScript("WebGridOnEditEnter", (evtArgs) => {
+    const column = evtArgs.detail.column;
+    if(column.field === 'ReorderLevel') {      
+        setTimeout(() => {
+            const rowId = evtArgs.detail.cellID.rowID;
+            const columnId = evtArgs.detail.cellID.columnID;
+            const inputTemplateId = `edit-cell-${rowId}-${columnId}`;
+            const element = document.getElementById(inputTemplateId);
+            element?.focus();
+        });
+    }
+}, false);
+//end eventHandler

--- a/code-gen-library/WebGridOnEditEnter/React.tsx
+++ b/code-gen-library/WebGridOnEditEnter/React.tsx
@@ -1,0 +1,22 @@
+//begin imports
+import { IgrGridBaseDirective, IgrGridEditEventArgs } from 'igniteui-react-grids';
+
+//end imports
+
+export class WebGridOnEditEnter {
+    //begin eventHandler
+    public webGridOnEditEnter(s: IgrGridBaseDirective, e: IgrGridEditEventArgs): void {
+
+        const column = s.getColumnByVisibleIndex(e.detail.cellID.columnID);
+        if(column.field === 'ReorderLevel') {
+            setTimeout(() => {
+                const rowId = e.detail.cellID.rowID;
+                const columnId = e.detail.cellID.columnID;
+                const inputTemplateId = `edit-cell-${rowId}-${columnId}`;
+                const x = document.getElementById(inputTemplateId);
+                x?.focus();
+            });
+        }
+    }
+    //end eventHandler
+}

--- a/code-gen-library/WebGridOnEditEnter/React.tsx
+++ b/code-gen-library/WebGridOnEditEnter/React.tsx
@@ -13,8 +13,8 @@ export class WebGridOnEditEnter {
                 const rowId = e.detail.cellID.rowID;
                 const columnId = e.detail.cellID.columnID;
                 const inputTemplateId = `edit-cell-${rowId}-${columnId}`;
-                const x = document.getElementById(inputTemplateId);
-                x?.focus();
+                const element = document.getElementById(inputTemplateId);
+                element?.focus();
             });
         }
     }

--- a/code-gen-library/WebGridOnEditEnter/Web.ts
+++ b/code-gen-library/WebGridOnEditEnter/Web.ts
@@ -1,5 +1,4 @@
 //begin imports
-import { IgcGridBaseDirective, IgcGridEditEventArgs } from 'igniteui-webcomponents-grids/grids';
 
 //end imports
 
@@ -12,8 +11,8 @@ export class WebGridOnEditEnter {
                 const rowId = args.detail.cellID.rowID;
                 const columnId = args.detail.cellID.columnID;
                 const inputTemplateId = `edit-cell-${rowId}-${columnId}`;
-                const x = document.getElementById(inputTemplateId);
-                x?.focus();
+                const element = document.getElementById(inputTemplateId);
+                element?.focus();
             });
         }
     }

--- a/code-gen-library/WebGridOnEditEnter/Web.ts
+++ b/code-gen-library/WebGridOnEditEnter/Web.ts
@@ -1,0 +1,21 @@
+//begin imports
+import { IgcGridBaseDirective, IgcGridEditEventArgs } from 'igniteui-webcomponents-grids/grids';
+
+//end imports
+
+export class WebGridOnEditEnter {
+    //begin eventHandler
+    public webGridOnEditEnter(args: any): void {
+        const column = args.detail.column;
+        if(column.field === 'ReorderLevel') {      
+            setTimeout(() => {
+                const rowId = args.detail.cellID.rowID;
+                const columnId = args.detail.cellID.columnID;
+                const inputTemplateId = `edit-cell-${rowId}-${columnId}`;
+                const x = document.getElementById(inputTemplateId);
+                x?.focus();
+            });
+        }
+    }
+    //end eventHandler
+}

--- a/samples/grids/grid/editing-columns.json
+++ b/samples/grids/grid/editing-columns.json
@@ -63,6 +63,7 @@
           "dataType": "Number",
           "sortable": true,
           "hasSummary": true,
+          "inlineEditorTemplateRef": "WebGridNumericColEditCellTemplate",
           "editable": true,
           "filterable": false
         }
@@ -72,6 +73,7 @@
   "modules": [
     "withDescriptions",
     "grids/WebGridModule",
-    "grids/WebPaginatorModule"
+    "grids/WebPaginatorModule",
+    "webinputs/WebInputModule"
   ]
 }

--- a/samples/grids/grid/editing-columns.json
+++ b/samples/grids/grid/editing-columns.json
@@ -16,6 +16,7 @@
           "perPage": 10
         }
       ],
+      "cellEditEnterRef": "WebGridOnEditEnter",
       "columnList": [
         {
           "type": "WebColumn",


### PR DESCRIPTION
Added edit templates on the `grid/editing-columns` sample for React, Blazor, Web Components, so that behaviour is the same as in the [Angular sample](https://www.infragistics.com/angular-demos/grid/grid-editing).

Closes #735