### PR TITLE
fix: replace contentChildLayoutList

### DIFF
--- a/code-gen-library/WebHierarchicalGridChangePinningConfig/React.tsx
+++ b/code-gen-library/WebHierarchicalGridChangePinningConfig/React.tsx
@@ -1,24 +1,22 @@
 //begin imports
 import { IgrPropertyEditorPropertyDescriptionChangedEventArgs } from 'igniteui-react-layouts';
-import { RowPinningPosition, IgrHierarchicalGrid } from 'igniteui-react-grids';
+import { RowPinningPosition } from 'igniteui-react-grids';
 //end imports
 
 export class WebHierarchicalGridChangePinningConfig {
     //begin eventHandler
     public webHierarchicalGridChangePinningConfig(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        var newPinningPosition = args.newValue === "Top" ? RowPinningPosition.Top : RowPinningPosition.Bottom;
-        var grid = CodeGenHelper.getDescription<IgrHierarchicalGrid>("content");
-        grid.pinning.rows = newPinningPosition;
-        var rowIsland1 = grid.contentChildLayoutList.filter(e => e.childDataKey == 'Albums');
-        rowIsland1[0].pinning.rows = newPinningPosition;
-    	var rowIsland2 = rowIsland1[0].contentChildLayoutList.filter(e => e.childDataKey == 'Songs');
-    	if(rowIsland2[0]) {
-            rowIsland2[0].pinning.rows = newPinningPosition;
+        const rows = args.newValue === "Top" ? RowPinningPosition.Top : RowPinningPosition.Bottom;
+        const columns = ColumnPinningPosition.End;
+        this._pinningConfig1 = { rows, columns };
+        this._pinningConfig2 = { rows, columns };
+        if ('_pinningConfig3' in this) {
+            this._pinningConfig3 = { rows, columns };
         }
-        var rowIsland3 = grid.contentChildLayoutList.filter(e => e.childDataKey == 'Tours');
-        if(rowIsland3[0]) {
-            rowIsland3[0].pinning.rows = newPinningPosition
+        if ('_pinningConfig4' in this) {
+            this._pinningConfig4 = { rows, columns };
         }
+        this.forceUpdate(); // due to not using state
     }
     //end eventHandler
 }

--- a/code-gen-library/WebRowIslandCellSelectionChange/React.tsx
+++ b/code-gen-library/WebRowIslandCellSelectionChange/React.tsx
@@ -1,12 +1,13 @@
 //begin imports
 import { IgrPropertyEditorPropertyDescriptionChangedEventArgs, IgrPropertyEditorPropertyDescriptionComponent } from 'igniteui-react-layouts';
-import { IgrHierarchicalGrid } from 'igniteui-react-grids';
+import { IgrRowIsland } from 'igniteui-react-grids';
 //end imports
 
 export class WebRowIslandCellSelectionChange {
     //begin eventHandler
     public webRowIslandCellSelectionChange(sender: any, args: IgrPropertyEditorPropertyDescriptionChangedEventArgs): void {
-        CodeGenHelper.getDescription<IgrHierarchicalGrid>("content").contentChildLayoutList[0].cellSelection = args.newValue.toLocaleLowerCase();
+        const rowIsland = document.getElementsByTagName("igc-row-island")[0] as IgrRowIsland;
+        rowIsland.cellSelection = args.newValue.toLocaleLowerCase();
     }
     //end eventHandler
 }


### PR DESCRIPTION
There's no public API on the HGrid to access row islands, but that doesn't matter - it should be replaced with state, but that can't be generated, so using the pinningCofig-s like one with `forceUpdate` and direct DOM query since that's what `ref` would resolve to for the other.