### PR TITLE
refactor(react): make base template modulesRegister optional

### DIFF
--- a/editor-templates/React/main-template/src/index.tsx
+++ b/editor-templates/React/main-template/src/index.tsx
@@ -24,11 +24,13 @@ import 'igniteui-react-grids/grids/themes/light/bootstrap.css';
 import 'igniteui-webcomponents/themes/light/bootstrap.css';
 //endifdef editor
 
+//ifdef modulesRegister
 const mods: any[] = [
     //insert modulesRegister
     //end modulesRegister
 ];
 mods.forEach((m) => m.register());
+//endifdef modulesRegister
 
 export default class Sample extends React.Component<any, any> {
     //insert bindingFields


### PR DESCRIPTION
Related to 19 changes where modules no longer needed for ig-react & ig-react-grids components

Reusing conditional check already implemented in the Web Components template `index.ts`.
Note this should produce _no immediate changes_, but is required to be able to omit that snippet when the metadata for those components is updated to skip emitting module registers like WC does.