### PR TITLE
fix(react): grid cascading combo errors

### DIFF
--- a/code-gen-library/WebGridWithComboRendered/React.tsx
+++ b/code-gen-library/WebGridWithComboRendered/React.tsx
@@ -19,10 +19,10 @@ export class WebGridWithComboRendered {
     public countries = [...CodeGenHelper.findByName<any[]>("worldCitiesAbove500K")].filter(x => this.countryNames.indexOf(x.Country) !== -1).filter((value, index, array) => array.findIndex(x => x.Country === value.Country) === index); 
     public regions = [...CodeGenHelper.findByName<any[]>("worldCitiesAbove500K")].filter((value, index, array) => array.findIndex(x => x.Region === value.Region) === index);
     public cities = [...CodeGenHelper.findByName<any[]>("worldCitiesAbove500K")].filter((value, index, array) => array.findIndex(x => x.Name === value.Name) === index);
-    private comboRefCollection = new Map<string, IgrCombo>();
+    private comboRefCollection = new Array<IgrCombo>();
     private comboRefs(r: IgrCombo) {
-        if (this && r && !this.comboRefCollection.get((r as any).props.name)) {
-            this.comboRefCollection.set((r as any).props.name, r);
+        if (this && r && !this.comboRefCollection.includes(r)) {
+            this.comboRefCollection.push(r);
         }
     }
 
@@ -33,8 +33,8 @@ export class WebGridWithComboRendered {
 
     public onCountryChange(rowId: string, args: CustomEvent<any>) {
         // find next combo
-        const regionCombo = this.comboRefCollection.get("region_" + rowId);
-        const cityCombo = this.comboRefCollection.get("city_" + rowId);
+        const regionCombo = this.comboRefCollection.find(c => c.name === "region_" + rowId);
+        const cityCombo = this.comboRefCollection.find(c => c.name === "city_" + rowId);
         const regions = this.regions;
         const newValue = args.detail.newValue[0];
         if (newValue === undefined) {
@@ -57,7 +57,7 @@ export class WebGridWithComboRendered {
 
     public onRegionChange(rowId: string, args: CustomEvent<any>) {
         // find next combo
-        const cityCombo = this.comboRefCollection.get("city_" + rowId);
+        const cityCombo = this.comboRefCollection.find(c => c.name === "city_" + rowId);
         const cities = this.cities;
         const newValue = args.detail.newValue[0];
         if (newValue === undefined) {


### PR DESCRIPTION
`props` don't exist anymore for those components and other props (like `name`, `data`, etc) are not set by the time ref is called and shouldn't be relied upon.

❗There's a "resize observer" error (from a 3rd party virtualization tooling) that's benign and should be ignored.

PS: The whole sample is quite atrocious BTW and needs a full rework eventually - no one should be using refs to collect components like that, it should be done via data/state & bindings. I understand the generation is limited and can't really define custom state, in which case this should've really been a manual one.