### PR TITLE
Add PlotAreaMargin to stacked Chart samples to ensure end markers are fully visible

### DIFF
--- a/samples/charts/data-chart/stacked-100-area-chart.json
+++ b/samples/charts/data-chart/stacked-100-area-chart.json
@@ -15,6 +15,10 @@
       "legendRef": "legend",
       "isHorizontalZoomEnabled": false,
       "isVerticalZoomEnabled": false,
+      "plotAreaMarginLeft": 12,
+      "plotAreaMarginTop": 12,
+      "plotAreaMarginRight": 12,
+      "plotAreaMarginBottom": 12,
       "axes": [
         {
           "type": "CategoryXAxis",

--- a/samples/charts/data-chart/stacked-100-line-chart.json
+++ b/samples/charts/data-chart/stacked-100-line-chart.json
@@ -15,6 +15,10 @@
       "legendRef": "legend",
       "isHorizontalZoomEnabled": false,
       "isVerticalZoomEnabled": false,
+      "plotAreaMarginLeft": 12,
+      "plotAreaMarginTop": 12,
+      "plotAreaMarginRight": 12,
+      "plotAreaMarginBottom": 12,
       "axes": [
         {
           "type": "CategoryXAxis",

--- a/samples/charts/data-chart/stacked-100-spline-area-chart.json
+++ b/samples/charts/data-chart/stacked-100-spline-area-chart.json
@@ -15,6 +15,10 @@
       "legendRef": "legend",
       "isHorizontalZoomEnabled": false,
       "isVerticalZoomEnabled": false,
+      "plotAreaMarginLeft": 12,
+      "plotAreaMarginTop": 12,
+      "plotAreaMarginRight": 12,
+      "plotAreaMarginBottom": 12,
       "axes": [
         {
           "type": "CategoryXAxis",

--- a/samples/charts/data-chart/stacked-100-spline-chart.json
+++ b/samples/charts/data-chart/stacked-100-spline-chart.json
@@ -15,6 +15,10 @@
       "legendRef": "legend",
       "isHorizontalZoomEnabled": false,
       "isVerticalZoomEnabled": false,
+      "plotAreaMarginLeft": 12,
+      "plotAreaMarginTop": 12,
+      "plotAreaMarginRight": 12,
+      "plotAreaMarginBottom": 12,
       "axes": [
         {
           "type": "CategoryXAxis",

--- a/samples/charts/data-chart/stacked-area-chart.json
+++ b/samples/charts/data-chart/stacked-area-chart.json
@@ -15,6 +15,10 @@
       "legendRef": "legend",
       "isHorizontalZoomEnabled": false,
       "isVerticalZoomEnabled": false,
+      "plotAreaMarginLeft": 12,
+      "plotAreaMarginTop": 12,
+      "plotAreaMarginRight": 12,
+      "plotAreaMarginBottom": 12,
       "axes": [
         {
           "type": "CategoryXAxis",

--- a/samples/charts/data-chart/stacked-line-chart.json
+++ b/samples/charts/data-chart/stacked-line-chart.json
@@ -15,6 +15,10 @@
       "legendRef": "legend",
       "isHorizontalZoomEnabled": false,
       "isVerticalZoomEnabled": false,
+      "plotAreaMarginLeft": 12,
+      "plotAreaMarginTop": 12,
+      "plotAreaMarginRight": 12,
+      "plotAreaMarginBottom": 12,
       "axes": [
         {
           "type": "CategoryXAxis",

--- a/samples/charts/data-chart/stacked-spline-area-chart.json
+++ b/samples/charts/data-chart/stacked-spline-area-chart.json
@@ -15,6 +15,10 @@
       "legendRef": "legend",
       "isHorizontalZoomEnabled": false,
       "isVerticalZoomEnabled": false,
+      "plotAreaMarginLeft": 12,
+      "plotAreaMarginTop": 12,
+      "plotAreaMarginRight": 12,
+      "plotAreaMarginBottom": 12,
       "axes": [
         {
           "type": "CategoryXAxis",

--- a/samples/charts/data-chart/stacked-spline-chart.json
+++ b/samples/charts/data-chart/stacked-spline-chart.json
@@ -15,6 +15,10 @@
       "legendRef": "legend",
       "isHorizontalZoomEnabled": false,
       "isVerticalZoomEnabled": false,
+      "plotAreaMarginLeft": 12,
+      "plotAreaMarginTop": 12,
+      "plotAreaMarginRight": 12,
+      "plotAreaMarginBottom": 12,
       "axes": [
         {
           "type": "CategoryXAxis",


### PR DESCRIPTION
Resolves #973 