### PR TITLE
Update version of igniteui-webcomponents-grids and igniteui-react-grids. Add i18n resources.

### DIFF
--- a/editor-templates/React/main-template/package.json
+++ b/editor-templates/React/main-template/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "igniteui-react-core": "19.3.2",
+    "igniteui-i18n-resources": "^1.0.2",
 //ifdef webgrids
     "igniteui-dockmanager": "^1.17.0",
 //endifdef webgrids

--- a/editor-templates/React/main-template/package.json
+++ b/editor-templates/React/main-template/package.json
@@ -39,7 +39,7 @@
     "igniteui-react-gauges": "19.3.2",
 //endifdef gauges, dashboards
 //ifdef webgrids
-    "igniteui-react-grids": "^19.5.0-beta.0 ",
+    "igniteui-react-grids": "^19.5.0-beta.3",
 //endifdef webgrids
 //ifdef grid, dashboards
     "igniteui-react-data-grids": "19.3.2",

--- a/editor-templates/WebComponents/main-template/package.json
+++ b/editor-templates/WebComponents/main-template/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "igniteui-webcomponents-core": "6.3.1",
+    "igniteui-i18n-resources": "^1.0.2",
 //ifdef editor, webinputs
     "igniteui-webcomponents": "^6.3.6",
 //endifdef editor, webinputs

--- a/editor-templates/WebComponents/main-template/package.json
+++ b/editor-templates/WebComponents/main-template/package.json
@@ -47,7 +47,7 @@
     "igniteui-webcomponents-gauges": "6.3.1",
 //endifdef gauges, dashboards
 //ifdef grid, webgrids, dashboards
-    "igniteui-webcomponents-grids": "^6.2.2",
+    "igniteui-webcomponents-grids": "6.3.0-rc.0",
 //endifdef grid, webgrids, dashboards
 //ifdef grid, inputs, webgrids, editor, layouts, dashboards
     "igniteui-webcomponents-inputs": "6.3.1",


### PR DESCRIPTION
- Updated version to match the version in wc-examples used to create a sample for localization.
- And following the steps from this guide https://github.com/IgniteUI/igniteui-wc-examples?tab=readme-ov-file#updating-version-of-igniteui-packages.

- Related to: 
https://github.com/IgniteUI/igniteui-wc-examples/pull/1155
https://github.com/IgniteUI/igniteui-xplat-docs/issues/1882