### PR TITLE
Cascading combo sample disabled fix

### DIFF
--- a/code-gen-library/WebGridCityDropDownTemplate/React.tsx
+++ b/code-gen-library/WebGridCityDropDownTemplate/React.tsx
@@ -14,10 +14,12 @@ export class WebGridCityDropDownTemplate {
         const id = cell.id.rowID;
         const comboId = "city_" + id;
         (this as any).comboRefs = (this as any).comboRefs.bind(this);
+        const existingCombo = this.comboRefCollection.find(c => c.name === comboId);
+        const cityData = existingCombo?.data || [];
         return (
         <>
             <div style={{display: "flex", flexDirection: "column"}}>
-                <IgrCombo ref={(this as any).comboRefs} placeholder="Choose City..." disabled={true} valueKey="Name"  displayKey="Name" name={comboId} singleSelect={true}>
+                <IgrCombo ref={(this as any).comboRefs} placeholder="Choose City..." disabled={cityData.length === 0} valueKey="Name"  displayKey="Name" name={comboId} singleSelect={true}>
                 </IgrCombo>
             </div>
         </>

--- a/code-gen-library/WebGridRegionDropDownTemplate/React.tsx
+++ b/code-gen-library/WebGridRegionDropDownTemplate/React.tsx
@@ -14,10 +14,12 @@ export class WebGridRegionDropDownTemplate {
         const id = cell.id.rowID;
         const comboId = "region_" + id;
         (this as any).comboRefs = (this as any).comboRefs.bind(this);
+        const existingCombo = this.comboRefCollection.find(c => c.name === comboId);
+        const regionData = existingCombo?.data || [];
         return (
         <>
             <div style={{display: "flex", flexDirection: "column"}}>
-                <IgrCombo ref={(this as any).comboRefs} onChange={(args: any) => { (this as any).onRegionChange(id, args) }} placeholder="Choose Region..." disabled={true} valueKey="Region"  displayKey="Region" singleSelect={true} name={comboId}>
+                <IgrCombo ref={(this as any).comboRefs} data={regionData} disabled={regionData.length === 0} onChange={(args: any) => { (this as any).onRegionChange(id, args) }} placeholder="Choose Region..." valueKey="Region"  displayKey="Region" singleSelect={true} name={comboId}>
                 </IgrCombo>
             </div>
         </>


### PR DESCRIPTION
fixes https://github.com/IgniteUI/igniteui-react-examples/issues/1041

The combo template is re-rendering when the dropdown expands, so the disabled={true} was happening before a value can be selected preventing the sample from working as intended.