### PR TITLE
add(option): Add Checkmark option to Marker Type dropdown in marker-options.json

### DIFF
--- a/samples/charts/category-chart/marker-options.json
+++ b/samples/charts/category-chart/marker-options.json
@@ -27,8 +27,8 @@
           "label": "Marker Type",
           "shouldOverrideDefaultEditor": true,
           "valueType": "EnumValue",
-          "dropDownValues": [ "Circle", "Automatic", "Triangle", "Pyramid", "Square", "Diamond", "Pentagon", "Hexagon", "Tetragram", "Pentagram", "Hexagram", "None" ],
-          "dropDownNames": [ "Circle", "Automatic", "Triangle", "Pyramid", "Square", "Diamond", "Pentagon", "Hexagon", "Tetragram", "Pentagram", "Hexagram", "None" ],
+          "dropDownValues": [ "Circle", "Checkmark", "Automatic", "Triangle", "Pyramid", "Square", "Diamond", "Pentagon", "Hexagon", "Tetragram", "Pentagram", "Hexagram", "None" ],
+          "dropDownNames": [ "Circle", "Checkmark", "Automatic", "Triangle", "Pyramid", "Square", "Diamond", "Pentagon", "Hexagon", "Tetragram", "Pentagram", "Hexagram", "None" ],
           "primitiveValue": "Circle",
           "changedRef": "EditorChangeUpdateMarkerType"
         }


### PR DESCRIPTION
Closes #1009 
Adding `Checkmark` type to the Category chart `Marker options` example.