### PR TITLE
chore(): bump WC version in WC and React editor templates

### DIFF
--- a/editor-templates/React/main-template/package.json
+++ b/editor-templates/React/main-template/package.json
@@ -57,7 +57,7 @@
     "igniteui-react-spreadsheet": "19.6.0-beta.2",
     "igniteui-react-spreadsheet-chart-adapter": "19.6.0-beta.2",
 //endifdef spreadsheet
-    "igniteui-webcomponents": "^7.0.0",
+    "igniteui-webcomponents": "^7.2.1",
     "lit-html": "^3.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/editor-templates/WebComponents/main-template/package.json
+++ b/editor-templates/WebComponents/main-template/package.json
@@ -25,7 +25,7 @@
     "babel-runtime": "^6.26.0",
     "igniteui-webcomponents-core": "7.1.0-beta.2",
 //ifdef editor, webinputs
-    "igniteui-webcomponents": "^7.1.2",
+    "igniteui-webcomponents": "^7.2.0",
 //endifdef editor, webinputs
 //ifdef charts, maps, dashboards
     "igniteui-webcomponents-charts": "7.1.0-beta.2",


### PR DESCRIPTION
The Web Components version was bumped in both the Web Components and React samples with the following PRs:
https://github.com/IgniteUI/igniteui-wc-examples/pull/1212
https://github.com/IgniteUI/igniteui-react-examples/pull/1067