### PR TITLE
Fix iOS gauge label handlers: correct event-arg types and number form…

### DIFF
--- a/code-gen-library/TestsAlignGaugeLabels/iOS.swift
+++ b/code-gen-library/TestsAlignGaugeLabels/iOS.swift
@@ -5,7 +5,7 @@ import UIKit;
 class TestsAlignGaugeLabels {
 
     //begin eventHandler
-    func testsAlignGaugeLabels(sender: Any?, args: IgsAlignRadialGaugeLabelEventArgs?) {
+    func testsAlignGaugeLabels(sender: Any?, args: IgsAlignLinearGraphLabelEventArgs?) {
         
 			args?.offsetX = 15
 			args?.offsetY = 12

--- a/code-gen-library/TestsAlignGaugeLabels2/iOS.swift
+++ b/code-gen-library/TestsAlignGaugeLabels2/iOS.swift
@@ -5,7 +5,7 @@ import UIKit;
 class TestsAlignGaugeLabels2 {
 
     //begin eventHandler
-    func testsAlignGaugeLabels2(sender: Any?, args: IgsAlignLinearGraphLabelEventArgs?) {
+    func testsAlignGaugeLabels2(sender: Any?, args: IgsAlignRadialGaugeLabelEventArgs?) {
         
 			args?.offsetX = 10
 			args?.offsetY = 10

--- a/code-gen-library/TestsLinearGaugePrependLabels/iOS.swift
+++ b/code-gen-library/TestsLinearGaugePrependLabels/iOS.swift
@@ -10,7 +10,7 @@ class TestsLinearGaugePrependLabels {
 		let parser = JsonDictionaryParser()
         let obj = parser.parse(json_: (o as! JsonDictionaryValue).value as! String) as! JsonDictionaryObject
         let v = (obj["Text"] as! JsonDictionaryValue).value as! String		
-		args!.label = v + String(describing: args!.value)
+		args!.label = v + (NumberUtil.doubleToMinDecimalsString(value: args!.value) ?? "")
     }
     //end eventHandler
 

--- a/code-gen-library/TestsLinearGaugeThousandsLabels/iOS.swift
+++ b/code-gen-library/TestsLinearGaugeThousandsLabels/iOS.swift
@@ -10,7 +10,7 @@ class TestsLinearGaugeThousandsLabels {
 		if args!.value > 1000 {
 			value = args!.value / 1000
 		}
-		args!.label = "$\(value) K"
+		args!.label = "$" + (NumberUtil.doubleToMinDecimalsString(value: value) ?? "") + " K"
     }
     //end eventHandler
 

--- a/code-gen-library/TestsRadialGaugeFormatLabelWithAllValues/iOS.swift
+++ b/code-gen-library/TestsRadialGaugeFormatLabelWithAllValues/iOS.swift
@@ -6,7 +6,7 @@ import Foundation
 class TestsRadialGaugeFormatLabelWithAllValues {
 
     //begin eventHandler
-    func testsRadialGaugeFormatLabelWithAllValues(sender: Any?, args: IgsAlignRadialGaugeLabelEventArgs?) {
+    func testsRadialGaugeFormatLabelWithAllValues(sender: Any?, args: IgsFormatRadialGaugeLabelEventArgs?) {
         
 		
 		let radToDeg = 180.0 / Double.pi
@@ -16,12 +16,12 @@ class TestsRadialGaugeFormatLabelWithAllValues {
 		let endAngleDeg   = (args!.endAngle * radToDeg).rounded(.toNearestOrEven)
 
 		args!.label =
-		  "Value:\(args!.value)," +
+		  "Value:\(NumberUtil.doubleToMinDecimalsString(value: args!.value) ?? "")," +
 		  "Angle:\(Int(angleDeg))," +
 		  "StartAngle:\(Int(startAngleDeg))," +
 		  "EndAngle:\(Int(endAngleDeg))," +
-		  "ActualMinimumValue:\(args!.actualMinimumValue)," +
-		  "ActualMaximumValue:\(args!.actualMaximumValue)"
+		  "ActualMinimumValue:\(NumberUtil.doubleToMinDecimalsString(value: args!.actualMinimumValue) ?? "")," +
+		  "ActualMaximumValue:\(NumberUtil.doubleToMinDecimalsString(value: args!.actualMaximumValue) ?? "")"
 
 
     }

--- a/code-gen-library/TestsRadialGaugeFormatLabelWithDecimals/iOS.swift
+++ b/code-gen-library/TestsRadialGaugeFormatLabelWithDecimals/iOS.swift
@@ -5,7 +5,7 @@ import UIKit;
 class TestsRadialGaugeFormatLabelWithDecimals {
 
     //begin eventHandler
-    func testsRadialGaugeFormatLabelWithDecimals(sender: Any?, args: IgsAlignLinearGraphLabelEventArgs?) {
+    func testsRadialGaugeFormatLabelWithDecimals(sender: Any?, args: IgsFormatRadialGaugeLabelEventArgs?) {
         
 		args!.label = String(format: "%.3f", args!.value) 
 

--- a/code-gen-library/TestsRadialGaugePrependLabels/iOS.swift
+++ b/code-gen-library/TestsRadialGaugePrependLabels/iOS.swift
@@ -5,12 +5,12 @@ import UIKit;
 class TestsRadialGaugePrependLabels {
 
     //begin eventHandler
-    func testsRadialGaugePrependLabels(sender: Any?, args: IgsAlignLinearGraphLabelEventArgs?) {
+    func testsRadialGaugePrependLabels(sender: Any?, args: IgsFormatRadialGaugeLabelEventArgs?) {
         let o = CodeGenHelper.findByName(Any.self, "LabelPrependValue")
 		let parser = JsonDictionaryParser()
         let obj = parser.parse(json_: (o as! JsonDictionaryValue).value as! String) as! JsonDictionaryObject
         let v = (obj["Text"] as! JsonDictionaryValue).value as! String		
-		args!.label = v + String(describing: args!.value)
+		args!.label = v + (NumberUtil.doubleToMinDecimalsString(value: args!.value) ?? "")
     }
     //end eventHandler
 


### PR DESCRIPTION
…atting

- Align handlers: use the matching Igs*AlignLinearGraph/RadialGaugeLabel event-arg types (were swapped).
- Format/prepend handlers: use the correct Igs*FormatRadialGaugeLabel event-arg type and wrap numeric values in NumberUtil.doubleToMinDecimalsString so labels render as expected on native-Swift iOS.