### PR TITLE
Fix CodeGenHelper import to platform core package in React/Angular ex…

### DIFF
--- a/code-gen-library/ColorEditorToggleSeriesBrush/Angular.ts
+++ b/code-gen-library/ColorEditorToggleSeriesBrush/Angular.ts
@@ -3,7 +3,7 @@ import { IgxToolCommandEventArgs } from 'igniteui-angular-layouts';
 import { IgxDataChartComponent, IgxSeriesComponent } from 'igniteui-angular-charts';
 //end imports
 
-import { CodeGenHelper } from 'igniteui-webcomponents-core';
+import { CodeGenHelper } from 'igniteui-angular-core';
 
 export class ColorEditorToggleSeriesBrush {
     //begin eventHandler

--- a/code-gen-library/RetailSalesPerformanceLocalDataSource/Angular.ts
+++ b/code-gen-library/RetailSalesPerformanceLocalDataSource/Angular.ts
@@ -1,5 +1,5 @@
 //begin imports
-import { CodeGenHelper } from 'igniteui-webcomponents-core';
+import { CodeGenHelper } from 'igniteui-angular-core';
 //end imports
 
 //begin data

--- a/code-gen-library/RetailSalesPerformanceLocalDataSource/React.ts
+++ b/code-gen-library/RetailSalesPerformanceLocalDataSource/React.ts
@@ -1,5 +1,5 @@
 //begin imports
-import { CodeGenHelper } from 'igniteui-webcomponents-core';
+import { CodeGenHelper } from 'igniteui-react-core';
 //end imports
 
 //begin data

--- a/code-gen-library/ToolbarToggleAnnotations/Angular.ts
+++ b/code-gen-library/ToolbarToggleAnnotations/Angular.ts
@@ -3,7 +3,7 @@ import { IgxToolCommandEventArgs } from 'igniteui-angular-layouts';
 import { IgxDataChartComponent, IgxSeriesComponent, IgxDataToolTipLayerComponent, IgxCrosshairLayerComponent, IgxFinalValueLayerComponent } from 'igniteui-angular-charts';
 //end imports
 
-import { CodeGenHelper } from 'igniteui-webcomponents-core';
+import { CodeGenHelper } from 'igniteui-angular-core';
 
 export class ToolbarToggleAnnotations {
     //begin eventHandler

--- a/code-gen-library/WebTreeGridReorderRowHandler/React.ts
+++ b/code-gen-library/WebTreeGridReorderRowHandler/React.ts
@@ -2,7 +2,7 @@
 import { IgrTreeGridComponent, IgrRowDragEndEventArgs } from 'igniteui-react-grids';
 //end imports
 
-import { CodeGenHelper } from 'igniteui-webcomponents-core';
+import { CodeGenHelper } from 'igniteui-react-core';
 
 export class WebTreeGridReorderRowHandler {
     //begin eventHandler


### PR DESCRIPTION
…amples

Five code-gen-library examples imported the shared CodeGenHelper from 'igniteui-webcomponents-core' instead of their own platform core package. React's Rollup/Vite build fails hard on the unresolvable WebComponents package (Angular's esbuild only warned), breaking the React test-host build.

Correct the import to 'igniteui-react-core' (React.ts) and 'igniteui-angular-core' (Angular.ts), matching the correct sibling examples:
- RetailSalesPerformanceLocalDataSource/React.ts, Angular.ts
- WebTreeGridReorderRowHandler/React.ts
- ToolbarToggleAnnotations/Angular.ts
- ColorEditorToggleSeriesBrush/Angular.ts