### PR TITLE
Select sample builds from emitted output changes

### DIFF
--- a/.github/workflows/codegen-validation.yml
+++ b/.github/workflows/codegen-validation.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   emit:
-    name: Emit affected samples (${{ matrix.platform }})
+    name: Emit all samples (${{ matrix.platform }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -40,7 +40,16 @@ jobs:
           npm ci
           npm run build
 
-      - name: Emit affected samples
-        run: >-
-          node tooling/src/cli.mjs check --platform=${{ matrix.platform }}
-          ${{ github.event_name == 'pull_request' && format('--changed-since={0}', github.event.pull_request.base.sha) || '' }}
+      - name: Emit every sample
+        run: node tooling/src/cli.mjs check --platform=${{ matrix.platform }} --quiet
+
+  required:
+    name: Code generation passed
+    if: always()
+    needs: emit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every platform emission
+        env:
+          EMIT_RESULT: ${{ needs.emit.result }}
+        run: test "$EMIT_RESULT" = success

--- a/.github/workflows/emitted-sample-builds.yml
+++ b/.github/workflows/emitted-sample-builds.yml
@@ -12,7 +12,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  impact:
+    name: Compare base and PR sample output
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: tooling/package-lock.json
+      - name: Install and build the Node emitter
+        working-directory: tooling
+        run: |
+          npm ci
+          npm run build
+      - name: Compare emitted sample folders
+        run: >-
+          node tooling/src/cli.mjs impact
+          --platform=Angular,React,WebComponents,Blazor
+          --changed-since=${{ github.event.pull_request.base.sha }}
+          --output=tooling/.generated/output-impact.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: emitted-output-impact
+          path: tooling/.generated/output-impact.json
+          retention-days: 7
+
   build:
+    needs: impact
+    if: always() && (github.event_name != 'pull_request' || needs.impact.result == 'success')
     name: Build affected ${{ matrix.platform }} samples (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -26,24 +59,55 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        if: github.event_name == 'pull_request'
+        with:
+          name: emitted-output-impact
+          path: tooling/.generated
+      - name: Check whether this shard has output changes
+        id: selected
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          count=$(jq --arg platform '${{ matrix.platform }}' \
+            '[.platforms[$platform].testingChanges[] | select(.kind != "removed")] | length' \
+            tooling/.generated/output-impact.json)
+          if (( ${{ matrix.shard }} < count )); then echo 'needed=true' >> "$GITHUB_OUTPUT"; fi
       - uses: actions/setup-node@v4
+        if: github.event_name != 'pull_request' || steps.selected.outputs.needed == 'true'
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: tooling/package-lock.json
       - uses: actions/setup-dotnet@v4
-        if: matrix.platform == 'Blazor'
+        if: (github.event_name != 'pull_request' || steps.selected.outputs.needed == 'true') && matrix.platform == 'Blazor'
         with:
           dotnet-version: '10.0.x'
       - name: Install and build the Node emitter
+        if: github.event_name != 'pull_request' || steps.selected.outputs.needed == 'true'
         working-directory: tooling
         run: |
           npm ci
           npm run build
       - name: Emit and compile sample projects
+        if: github.event_name != 'pull_request' || steps.selected.outputs.needed == 'true'
         run: >-
           node tooling/src/cli.mjs sample-build
           --platform=${{ matrix.platform }}
           --shard-index=${{ matrix.shard }}
           --shard-total=12
-          ${{ github.event_name == 'pull_request' && format('--changed-since={0}', github.event.pull_request.base.sha) || '' }}
+          ${{ github.event_name == 'pull_request' && '--impact-manifest=tooling/.generated/output-impact.json' || '' }}
+
+  required:
+    name: Emitted sample builds passed
+    if: always()
+    needs: [impact, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the impact comparison and every build shard
+        env:
+          IMPACT_RESULT: ${{ needs.impact.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          test "$BUILD_RESULT" = success
+          if [ '${{ github.event_name }}' = pull_request ]; then test "$IMPACT_RESULT" = success; fi

--- a/.github/workflows/library-validation.yml
+++ b/.github/workflows/library-validation.yml
@@ -2,10 +2,6 @@ name: Emitted library compilation
 
 on:
   pull_request:
-    paths:
-      - 'code-gen-library/**'
-      - 'tooling/**'
-      - '.github/workflows/library-validation.yml'
   workflow_dispatch:
     inputs:
       full:
@@ -60,3 +56,14 @@ jobs:
           path: tooling/.generated/library/${{ matrix.platform }}
           if-no-files-found: ignore
           retention-days: 7
+
+  required:
+    name: Emitted libraries passed
+    if: always()
+    needs: compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every platform library validation
+        env:
+          COMPILE_RESULT: ${{ needs.compile.result }}
+        run: test "$COMPILE_RESULT" = success

--- a/.github/workflows/sample-runtime.yml
+++ b/.github/workflows/sample-runtime.yml
@@ -42,7 +42,6 @@ jobs:
         working-directory: tooling/runtime
         run: >-
           node run.mjs --samples --skip-browser-install
-          ${{ github.event_name == 'pull_request' && format('--changed-since={0}', github.event.pull_request.base.sha) || '' }}
           ${{ inputs.filter && format('--filter={0}', inputs.filter) || '' }}
       - name: Keep emitted runtime library and blank screenshots
         if: always()

--- a/.github/workflows/sync-downstream-prs.yml
+++ b/.github/workflows/sync-downstream-prs.yml
@@ -34,7 +34,7 @@ jobs:
   sync:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     environment: downstream-sync
     strategy:
       fail-fast: false

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -42,11 +42,20 @@ and Uno):
 node src/cli.mjs check --source=../samples/gauges/linear-gauge/needle.json
 ```
 
-On a pull-request checkout, validate only altered samples:
+Create a platform-aware manifest by comparing every emitted sample folder at the merge base and
+the pull-request head:
 
 ```sh
-node src/cli.mjs check --changed-since=origin/main
+node src/cli.mjs impact \
+  --changed-since=origin/main \
+  --platform=Angular,React,WebComponents,Blazor \
+  --output=/tmp/output-impact.json
 ```
+
+The folder mapping is exact: `samples/grids/data-grid/performance.json` owns the emitted
+`grids/data-grid/performance/` folder. The manifest records separate testing and normal-emission
+changes. Testing includes exclusions carrying `"test": true`; downstream synchronization uses the
+normal-emission set so it never removes a platform-excluded, manually maintained folder.
 
 Emit the complete code-generation library, or compile only changed items and their requirements:
 
@@ -72,7 +81,7 @@ Emit and compile sample projects. Shards deterministically divide the complete s
 changing what is covered:
 
 ```sh
-node src/cli.mjs sample-build --platform=Angular --changed-since=origin/main
+node src/cli.mjs sample-build --platform=Angular --impact-manifest=/tmp/output-impact.json
 node src/cli.mjs sample-build --platform=Blazor --source=../samples/gauges/linear-gauge/needle.json
 node src/cli.mjs sample-build --platform=WebComponents --shard-index=0 --shard-total=12
 ```
@@ -119,9 +128,11 @@ documentation work—`id`, `ref`, `channel`, `item`, `include`, `omit`, `exclude
 ## Pull-request automation
 
 `.github/workflows/codegen-validation.yml` makes full-repository product emission an unconditional
-PR check for all seven platforms. `.github/workflows/emitted-sample-builds.yml` divides the full
-sample set into 12 shards and performs real project builds for Angular, React, Web Components, and
-Blazor on every PR (48 build jobs in total).
+PR check for all seven platforms. The browser runtime check also loads the complete supported sample
+set on every PR. `.github/workflows/emitted-sample-builds.yml` compares base and head output, divides
+only changed sample/platform folders into 12 shards, and performs real project builds for Angular,
+React, Web Components, and Blazor. Stable aggregate jobs (`Code generation passed`, `Emitted sample
+builds passed`, and `Emitted libraries passed`) are the checks intended for repository rulesets.
 
 `.github/workflows/sync-downstream-prs.yml` creates or refreshes ten downstream PRs:
 four web repositories, each targeting both `vnext` (staging) and `master` (production), plus
@@ -132,7 +143,8 @@ For an upstream branch named `feature/foo`, the downstream branches are:
 - `feature/foo--master`
 
 The suffixed web branches are necessary because the two downstream bases can contain different
-packages and sample structure. Both are rebuilt from their own base on every upstream update, so
+packages and sample structure. Both receive only folders identified by the upstream base-versus-head
+output manifest, applied to their own base on every upstream update, so
 they can be reviewed and merged independently without leaking `vnext` commits into `master`.
 The native peers use `<upstream-branch>--main`. Uno keeps its native Uno project shell and receives
 only the Uno-targeted XAML/C# emitted by the product renderer.
@@ -143,7 +155,8 @@ Repository setup required:
    key by following the [downstream sync App runbook](../.github/DOWNSTREAM_SYNC_APP.md).
 2. Create the `downstream-sync` GitHub Actions environment and choose protection rules compatible
    with whether every upstream PR update should synchronize automatically.
-3. Add the `Cross-platform code generation` job as a required branch-protection check.
+3. Require `Code generation passed`, `Emitted sample builds passed`, `Emitted libraries passed`, and
+   the Web Components runtime `load` job in the repository ruleset.
 
 Fork pull requests run validation but do not receive the App private key and therefore do not create
 downstream branches.

--- a/tooling/src/cli.mjs
+++ b/tooling/src/cli.mjs
@@ -7,10 +7,14 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { CODE_FENCE_LANG, fenceEmitter, libraryItemLookup } from './snippet-emit.mjs';
+import {
+    compareOutputTrees, emittableSampleNames, readImpactManifest,
+} from './output-impact.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const TOOLING_ROOT = path.resolve(HERE, '..');
-const EXAMPLES_ROOT = path.resolve(TOOLING_ROOT, '..');
+const EXAMPLES_ROOT = process.env.XPLAT_EXAMPLES_ROOT
+    ? path.resolve(process.env.XPLAT_EXAMPLES_ROOT) : path.resolve(TOOLING_ROOT, '..');
 const require = createRequire(import.meta.url);
 
 function fail(message) {
@@ -33,7 +37,9 @@ function argsOf(argv) {
 }
 
 function loadApi() {
-    const built = path.join(TOOLING_ROOT, 'dist', 'codegen-api.cjs');
+    const built = process.env.XPLAT_CODEGEN_ADAPTER
+        ? path.resolve(process.env.XPLAT_CODEGEN_ADAPTER)
+        : path.join(TOOLING_ROOT, 'dist', 'codegen-api.cjs');
     if (!fs.existsSync(built)) throw new Error('the product adapter is not built; run npm run build in tooling');
     require('./dom-shim.cjs');
     return require(built);
@@ -96,6 +102,13 @@ function exportSourcesFrom(opts) {
 }
 
 function buildSourcesFrom(opts) {
+    if (opts['impact-manifest']) {
+        if (!opts.platform) throw new Error('--impact-manifest requires --platform');
+        return readImpactManifest(path.resolve(String(opts['impact-manifest'])), opts.platform, 'testing')
+            .filter(change => change.kind !== 'removed')
+            .map(change => path.join(EXAMPLES_ROOT, 'samples', change.sample))
+            .filter(fs.existsSync);
+    }
     if (!opts['changed-since']) return sourcesFrom(opts);
     const changes = changedPaths(opts['changed-since']);
     // Project templates, platform/exclusion configuration, the generator itself, and the product
@@ -115,6 +128,20 @@ function buildSourcesFrom(opts) {
         return items.some(item => text.includes(`"${item}"`));
     });
     return [...new Set([...direct, ...impacted])].sort();
+}
+
+function exportChangesFrom(opts) {
+    if (!opts['impact-manifest']) return null;
+    if (!opts.platform) throw new Error('--impact-manifest requires --platform');
+    return readImpactManifest(path.resolve(String(opts['impact-manifest'])), opts.platform, 'emission');
+}
+
+function exportSourcesFromImpact(opts) {
+    const changes = exportChangesFrom(opts);
+    if (changes === null) return null;
+    return changes.filter(change => change.kind !== 'removed')
+        .map(change => path.join(EXAMPLES_ROOT, 'samples', change.sample))
+        .filter(fs.existsSync);
 }
 
 /**
@@ -263,7 +290,7 @@ function verifyProject(project, sample, platform) {
 
 function emitFiles(api, platform, files, output, {
     clean = false, sourceOverlay = false, bootstrapFrom, collectErrors = false,
-    testing = false, includeExcluded = false,
+    testing = false, includeExcluded = false, quiet = false,
 } = {}) {
     let emitted = 0, skipped = 0;
     const destinations = [];
@@ -288,7 +315,10 @@ function emitFiles(api, platform, files, output, {
             writeProject(project, destination, { sourceOverlay });
             destinations.push(destination);
             emitted++;
-            console.log(`[${platform}] ${path.relative(EXAMPLES_ROOT, file)} -> ${path.relative(EXAMPLES_ROOT, destination)}`);
+            if (!quiet) {
+                console.log(`[${platform}] ${path.relative(EXAMPLES_ROOT, file)} -> ` +
+                    `${path.relative(EXAMPLES_ROOT, destination)}`);
+            }
         } catch (error) {
             if (!collectErrors) throw error;
             const failure = `${path.relative(EXAMPLES_ROOT, file)}: ${error.message.split('\n')[0]}`;
@@ -302,6 +332,11 @@ function emitFiles(api, platform, files, output, {
 }
 
 function removeChangedOutputs(opts, output) {
+    const impact = exportChangesFrom(opts);
+    if (impact !== null && opts.clean) {
+        for (const change of impact) safelyEmpty(path.join(path.resolve(output), change.folder), output);
+        return;
+    }
     if (!opts['changed-since'] || !opts.clean) return;
     // Existing included samples are cleaned immediately before they are rewritten. Here only an
     // upstream deletion should remove a downstream directory; an existing platform-excluded sample
@@ -366,19 +401,98 @@ function transformMarkdown(content, platform, api) {
     });
 }
 
+function outputImpact(api, opts) {
+    if (!opts['changed-since'] || !opts.output) {
+        throw new Error('impact needs --changed-since and --output');
+    }
+    const platforms = opts.platform ? String(opts.platform).split(',')
+        : readJson(path.join(TOOLING_ROOT, 'xplat-codegen.json')).platforms;
+    const mergeBase = execFileSync('git', ['merge-base', String(opts['changed-since']), 'HEAD'], {
+        cwd: EXAMPLES_ROOT, encoding: 'utf8',
+    }).trim();
+    const headSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: EXAMPLES_ROOT, encoding: 'utf8',
+    }).trim();
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xplat-output-impact-'));
+    const baseRoot = path.join(workspace, 'base');
+    const cli = fileURLToPath(import.meta.url);
+    const manifest = { version: 1, base: mergeBase, head: headSha, platforms: {} };
+    let completed = false;
+    try {
+        execFileSync('git', ['clone', '--shared', '--no-checkout', EXAMPLES_ROOT, baseRoot], { stdio: 'inherit' });
+        execFileSync('git', ['checkout', '--detach', mergeBase], { cwd: baseRoot, stdio: 'inherit' });
+        execFileSync('npm', ['ci', '--no-audit', '--no-fund'], {
+            cwd: path.join(baseRoot, 'tooling'), stdio: 'inherit',
+        });
+        execFileSync('npm', ['run', 'build'], { cwd: path.join(baseRoot, 'tooling'), stdio: 'inherit' });
+
+        for (const platform of platforms) {
+            const baseOutput = path.join(workspace, 'output', 'base', platform);
+            const headOutput = path.join(workspace, 'output', 'head', platform);
+            emitFiles(api, platform,
+                walk(path.join(EXAMPLES_ROOT, 'samples'), file => file.endsWith('.json')),
+                headOutput, { clean: true, collectErrors: true, testing: true, quiet: true });
+            execFileSync(process.execPath, [cli, 'export', `--platform=${platform}`,
+                `--source=${path.join(baseRoot, 'samples')}`, `--output=${baseOutput}`,
+                '--clean', '--testing', '--quiet'], {
+                cwd: EXAMPLES_ROOT,
+                stdio: 'inherit',
+                env: {
+                    ...process.env,
+                    XPLAT_EXAMPLES_ROOT: baseRoot,
+                    XPLAT_CODEGEN_ADAPTER: path.join(baseRoot, 'tooling', 'dist', 'codegen-api.cjs'),
+                },
+            });
+            const common = {
+                baseOutput, headOutput,
+                baseSamples: path.join(baseRoot, 'samples'),
+                headSamples: path.join(EXAMPLES_ROOT, 'samples'),
+            };
+            const emissionChanges = compareOutputTrees({
+                ...common,
+                baseIncluded: emittableSampleNames(baseRoot, platform),
+                headIncluded: emittableSampleNames(EXAMPLES_ROOT, platform),
+            });
+            const testingChanges = compareOutputTrees({
+                ...common,
+                baseIncluded: emittableSampleNames(baseRoot, platform, { testing: true }),
+                headIncluded: emittableSampleNames(EXAMPLES_ROOT, platform, { testing: true }),
+            });
+            manifest.platforms[platform] = { emissionChanges, testingChanges };
+            console.log(`[${platform}] ${testingChanges.length} build impact(s), ` +
+                `${emissionChanges.length} downstream emission impact(s)`);
+        }
+        const output = path.resolve(String(opts.output));
+        fs.mkdirSync(path.dirname(output), { recursive: true });
+        fs.writeFileSync(output, JSON.stringify(manifest, null, 2) + '\n');
+        console.log(`output impact: ${output}`);
+        completed = true;
+    } finally {
+        if (completed) fs.rmSync(workspace, { recursive: true, force: true });
+        else console.error(`output-impact evidence retained at ${workspace}`);
+    }
+}
+
 async function main() {
     const [command = 'help', ...rest] = process.argv.slice(2);
     const opts = argsOf(rest);
     const config = readJson(path.join(TOOLING_ROOT, 'xplat-codegen.json'));
     const api = command === 'help' ? null : loadApi();
 
+    if (command === 'impact') {
+        outputImpact(api, opts);
+        return;
+    }
+
     if (command === 'export') {
         if (!opts.platform || !opts.output) throw new Error('export needs --platform and --output');
         removeChangedOutputs(opts, opts.output);
-        emitFiles(api, opts.platform, exportSourcesFrom(opts), opts.output, {
+        emitFiles(api, opts.platform, exportSourcesFromImpact(opts) ?? exportSourcesFrom(opts), opts.output, {
             clean: opts.clean === true,
             sourceOverlay: opts['source-overlay'] === true,
             bootstrapFrom: opts['bootstrap-from'],
+            testing: opts.testing === true,
+            quiet: opts.quiet === true,
         });
         return;
     }
@@ -392,6 +506,7 @@ async function main() {
                     collectErrors: true,
                     testing: true,
                     includeExcluded: opts['include-excluded'] === true,
+                    quiet: opts.quiet === true,
                 });
             }
         }
@@ -548,7 +663,7 @@ async function main() {
         }
         return;
     }
-    console.log('Usage:\n  xplat-codegen export --platform NAME --source PATH --output PATH [--clean] [--changed-since REF]\n  xplat-codegen check [--changed-since REF] [--platform A,B] [--include-excluded]\n  xplat-codegen sample-build --platform NAME [--changed-since REF | --source PATH] [--output PATH] [--limit N] [--shard-index N --shard-total N] [--include-excluded] [--include-web-grids]\n  xplat-codegen library --platform NAME --output PATH [--only A,B] [--clean]\n  xplat-codegen library-check --platform NAME [--changed-since REF | --only A,B | --all]\n  xplat-codegen snippets --source PATH --output PATH [--platform A,B]');
+    console.log('Usage:\n  xplat-codegen impact --changed-since REF --output FILE [--platform A,B]\n  xplat-codegen export --platform NAME --source PATH --output PATH [--clean] [--impact-manifest FILE]\n  xplat-codegen check [--platform A,B] [--include-excluded]\n  xplat-codegen sample-build --platform NAME [--impact-manifest FILE | --source PATH] [--output PATH] [--limit N] [--shard-index N --shard-total N] [--include-excluded] [--include-web-grids]\n  xplat-codegen library --platform NAME --output PATH [--only A,B] [--clean]\n  xplat-codegen library-check --platform NAME [--changed-since REF | --only A,B | --all]\n  xplat-codegen snippets --source PATH --output PATH [--platform A,B]');
 }
 
 main().catch(error => fail(error.stack ?? error.message));

--- a/tooling/src/output-impact.mjs
+++ b/tooling/src/output-impact.mjs
@@ -1,0 +1,89 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function walkFiles(root, dir = root, found = []) {
+    if (!fs.existsSync(dir)) return found;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walkFiles(root, full, found);
+        else if (entry.isFile()) found.push(path.relative(root, full).split(path.sep).join('/'));
+    }
+    return found;
+}
+
+export function sampleNames(samplesRoot) {
+    return walkFiles(samplesRoot).filter(name => name.endsWith('.json')).sort();
+}
+
+export function outputFolderForSample(sample) {
+    if (!sample.endsWith('.json')) throw new Error(`sample path must end in .json: ${sample}`);
+    return sample.slice(0, -'.json'.length);
+}
+
+export function outputDigest(outputRoot, sample) {
+    const folder = path.join(outputRoot, outputFolderForSample(sample));
+    if (!fs.existsSync(folder)) return null;
+    const hash = crypto.createHash('sha256');
+    for (const relative of walkFiles(folder).sort()) {
+        hash.update(relative);
+        hash.update('\0');
+        hash.update(fs.readFileSync(path.join(folder, relative)));
+        hash.update('\0');
+    }
+    return hash.digest('hex');
+}
+
+function platformSections(examplesRoot, platform) {
+    const configured = platform.toLowerCase() === 'uno' ? 'winui' : platform.toLowerCase();
+    return JSON.parse(fs.readFileSync(path.join(examplesRoot, 'config.json'), 'utf8')).platforms
+        .filter(one => one.name === 'All' || one.name.toLowerCase() === configured);
+}
+
+export function emittableSampleNames(examplesRoot, platform, { testing = false } = {}) {
+    const samplesRoot = path.join(examplesRoot, 'samples');
+    const sections = platformSections(examplesRoot, platform);
+    return sampleNames(samplesRoot).filter(sample => {
+        const parsed = JSON.parse(fs.readFileSync(path.join(samplesRoot, sample), 'utf8'));
+        if (parsed.export === false) return false;
+        if (Array.isArray(parsed.export) &&
+            !parsed.export.some(one => String(one).toLowerCase() === platform.toLowerCase())) return false;
+        const relative = sample.toLowerCase();
+        return !sections.some(section => (section.exclusions ?? []).some(rule => {
+            const candidate = String(rule.path).replace(/\\/g, '/').replace(/^samples\//, '').toLowerCase();
+            const matches = candidate.endsWith('/') ? relative.startsWith(candidate) : relative === candidate;
+            return matches && !(testing && rule.test === true);
+        }));
+    });
+}
+
+/**
+ * Compares the emitted folder belonging to every source sample in either revision.
+ * Output folders deliberately preserve the source path without `.json`, so the result is directly
+ * consumable by build selection and downstream synchronization.
+ */
+export function compareOutputTrees({
+    baseOutput, headOutput, baseSamples, headSamples, baseIncluded = null, headIncluded = null,
+}) {
+    const baseNames = new Set(baseIncluded ?? sampleNames(baseSamples));
+    const headNames = new Set(headIncluded ?? sampleNames(headSamples));
+    const names = [...new Set([...baseNames, ...headNames])].sort();
+    const changes = [];
+    for (const sample of names) {
+        const before = baseNames.has(sample) ? outputDigest(baseOutput, sample) : null;
+        const after = headNames.has(sample) ? outputDigest(headOutput, sample) : null;
+        if (before === after) continue;
+        const kind = before === null ? 'added' : after === null ? 'removed' : 'modified';
+        changes.push({ sample, folder: outputFolderForSample(sample), kind });
+    }
+    return changes;
+}
+
+export function readImpactManifest(file, platform, scope = 'testing') {
+    const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const changes = manifest.platforms?.[platform]?.[`${scope}Changes`];
+    if (manifest.version !== 1 || !Array.isArray(changes)) {
+        throw new Error(`impact manifest has no version 1 entry for ${platform}: ${file}`);
+    }
+    return changes;
+}

--- a/tooling/src/sync-downstream.mjs
+++ b/tooling/src/sync-downstream.mjs
@@ -28,8 +28,11 @@ function safeBranchName(value) {
 
 const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xplat-downstream-'));
 const clone = path.join(workspace, repository.split('/').pop());
+const impact = path.join(workspace, `output-impact-${platform}.json`);
 
 try {
+    run('node', [path.join(ROOT, 'tooling/src/cli.mjs'), 'impact', `--platform=${platform}`,
+        `--changed-since=${baseSha}`, `--output=${impact}`], ROOT);
     run('gh', ['repo', 'clone', repository, clone, '--', '--filter=blob:none']);
     for (const base of bases) {
         const peerBranch = safeBranchName(`${upstreamBranch}--${base}`);
@@ -37,7 +40,7 @@ try {
         run('git', ['checkout', '-B', peerBranch, `origin/${base}`], clone);
 
         const exportArgs = [path.join(ROOT, 'tooling/src/cli.mjs'), 'export', `--platform=${platform}`,
-            `--changed-since=${baseSha}`, `--output=${path.join(clone, 'samples')}`, '--clean'];
+            `--impact-manifest=${impact}`, `--output=${path.join(clone, 'samples')}`, '--clean'];
         if (platform === 'Uno') {
             // Uno and WinUI share generated XAML/C#, but Uno's independently buildable project shell
             // is materially different. Seed that shell from the downstream repository and overlay

--- a/tooling/test/tooling.test.mjs
+++ b/tooling/test/tooling.test.mjs
@@ -6,12 +6,135 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import {
+    compareOutputTrees, emittableSampleNames, outputFolderForSample,
+} from '../src/output-impact.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CLI = path.join(ROOT, 'src', 'cli.mjs');
 const require = createRequire(import.meta.url);
 require('../src/dom-shim.cjs');
 const { emitProject } = require('../dist/codegen-api.cjs');
+
+test('maps emitted folder diffs back to added, modified, and removed samples', () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xplat-impact-test-'));
+    const write = (relative, content) => {
+        const file = path.join(workspace, relative);
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, content);
+    };
+    try {
+        for (const sample of ['same.json', 'changed.json', 'removed.json']) {
+            write(`base-samples/group/${sample}`, '{}');
+        }
+        for (const sample of ['same.json', 'changed.json', 'added.json']) {
+            write(`head-samples/group/${sample}`, '{}');
+        }
+        write('base-output/group/same/file.ts', 'same');
+        write('head-output/group/same/file.ts', 'same');
+        write('base-output/group/changed/file.ts', 'before');
+        write('head-output/group/changed/file.ts', 'after');
+        write('base-output/group/removed/file.ts', 'removed');
+        write('head-output/group/added/file.ts', 'added');
+
+        const changes = compareOutputTrees({
+            baseOutput: path.join(workspace, 'base-output'),
+            headOutput: path.join(workspace, 'head-output'),
+            baseSamples: path.join(workspace, 'base-samples'),
+            headSamples: path.join(workspace, 'head-samples'),
+        });
+        assert.deepEqual(changes, [
+            { sample: 'group/added.json', folder: 'group/added', kind: 'added' },
+            { sample: 'group/changed.json', folder: 'group/changed', kind: 'modified' },
+            { sample: 'group/removed.json', folder: 'group/removed', kind: 'removed' },
+        ]);
+        assert.equal(outputFolderForSample('grids/data-grid/performance.json'),
+            'grids/data-grid/performance');
+    } finally {
+        fs.rmSync(workspace, { recursive: true, force: true });
+    }
+});
+
+test('a shared template output change selects every sample folder it changes', () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xplat-template-impact-test-'));
+    try {
+        for (const sample of ['one', 'two', 'three']) {
+            const source = path.join(workspace, 'samples', `${sample}.json`);
+            const before = path.join(workspace, 'before', sample, 'template.txt');
+            const after = path.join(workspace, 'after', sample, 'template.txt');
+            for (const file of [source, before, after]) fs.mkdirSync(path.dirname(file), { recursive: true });
+            fs.writeFileSync(source, '{}');
+            fs.writeFileSync(before, 'old shared template');
+            fs.writeFileSync(after, 'new shared template');
+        }
+        const changes = compareOutputTrees({
+            baseOutput: path.join(workspace, 'before'),
+            headOutput: path.join(workspace, 'after'),
+            baseSamples: path.join(workspace, 'samples'),
+            headSamples: path.join(workspace, 'samples'),
+        });
+        assert.deepEqual(changes.map(change => change.sample), ['one.json', 'three.json', 'two.json']);
+    } finally {
+        fs.rmSync(workspace, { recursive: true, force: true });
+    }
+});
+
+test('keeps test-opted exclusions out of the downstream emission impact set', () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xplat-impact-config-test-'));
+    const samples = path.join(workspace, 'samples');
+    fs.mkdirSync(path.join(samples, 'group'), { recursive: true });
+    fs.writeFileSync(path.join(samples, 'group/normal.json'), '{}');
+    fs.writeFileSync(path.join(samples, 'group/test-only.json'), '{}');
+    fs.writeFileSync(path.join(workspace, 'config.json'), JSON.stringify({
+        platforms: [{ name: 'WebComponents', exclusions: [
+            { path: 'group/test-only.json', test: true },
+        ] }],
+    }));
+    try {
+        assert.deepEqual(emittableSampleNames(workspace, 'WebComponents'), ['group/normal.json']);
+        assert.deepEqual(emittableSampleNames(workspace, 'WebComponents', { testing: true }),
+            ['group/normal.json', 'group/test-only.json']);
+    } finally {
+        fs.rmSync(workspace, { recursive: true, force: true });
+    }
+});
+
+test('applies an emission impact manifest without touching unrelated downstream folders', () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'xplat-impact-export-test-'));
+    const output = path.join(workspace, 'samples');
+    const manifest = path.join(workspace, 'impact.json');
+    const stale = path.join(output, 'gauges/linear-gauge/needle/stale.txt');
+    const removed = path.join(output, 'gauges/linear-gauge/removed/stale.txt');
+    const unrelated = path.join(output, 'manually-maintained/keep.txt');
+    for (const file of [stale, removed, unrelated]) {
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, 'old');
+    }
+    fs.writeFileSync(manifest, JSON.stringify({
+        version: 1,
+        platforms: {
+            WebComponents: {
+                emissionChanges: [
+                    { sample: 'gauges/linear-gauge/needle.json', folder: 'gauges/linear-gauge/needle', kind: 'modified' },
+                    { sample: 'gauges/linear-gauge/removed.json', folder: 'gauges/linear-gauge/removed', kind: 'removed' },
+                ],
+                testingChanges: [],
+            },
+        },
+    }));
+    try {
+        execFileSync(process.execPath, [CLI, 'export', '--platform=WebComponents',
+            `--impact-manifest=${manifest}`, `--output=${output}`, '--clean'],
+        { cwd: ROOT, stdio: 'pipe' });
+        assert.equal(fs.existsSync(stale), false);
+        assert.equal(fs.existsSync(path.join(output,
+            'gauges/linear-gauge/needle/src/index.ts')), true);
+        assert.equal(fs.existsSync(path.dirname(removed)), false);
+        assert.equal(fs.readFileSync(unrelated, 'utf8'), 'old');
+    } finally {
+        fs.rmSync(workspace, { recursive: true, force: true });
+    }
+});
 
 test('emits a complete sample project through the product renderer', () => {
     const output = fs.mkdtempSync(path.join(os.tmpdir(), 'xplat-project-test-'));


### PR DESCRIPTION
Compares merge-base and PR-head emitted sample folders per platform and uses the resulting manifest for expensive sample compilation and downstream synchronization. Full emission and Web Components runtime validation continue to cover every sample on every PR. Adds stable aggregate checks for repository rulesets.