### PR TITLE
Name the required Web Components runtime check

### DIFF
--- a/.github/workflows/sample-runtime.yml
+++ b/.github/workflows/sample-runtime.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   load:
+    name: Web Components runtime passed
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -156,7 +156,7 @@ Repository setup required:
 2. Create the `downstream-sync` GitHub Actions environment and choose protection rules compatible
    with whether every upstream PR update should synchronize automatically.
 3. Require `Code generation passed`, `Emitted sample builds passed`, `Emitted libraries passed`, and
-   the Web Components runtime `load` job in the repository ruleset.
+   `Web Components runtime passed` in the repository ruleset.
 
 Fork pull requests run validation but do not receive the App private key and therefore do not create
 downstream branches.


### PR DESCRIPTION
Gives the runtime job the explicit stable check name Web Components runtime passed so it appears clearly in the repository ruleset required-check selector. Updates the tooling runbook to use that exact name.